### PR TITLE
Don't use LimitType at all to resolve ILog

### DIFF
--- a/docs/examples/log4net.rst
+++ b/docs/examples/log4net.rst
@@ -32,11 +32,13 @@ Here's a sample module that configures Autofac to inject ``ILog`` parameters bas
 
       private static void OnComponentPreparing(object sender, PreparingEventArgs e)
       {
-        var t = e.Component.Target.Activator.LimitType;
         e.Parameters = e.Parameters.Union(
           new[]
           {
-            new ResolvedParameter((p, i) => p.ParameterType == typeof(ILog), (p, i) => LogManager.GetLogger(t)),
+            new ResolvedParameter( 
+                (p, i) => p.ParameterType == typeof(ILog), 
+                (p, i) => LogManager.GetLogger(p.MemberInfo.DeclaringType)
+            ),
           });
       }
 


### PR DESCRIPTION
Even after changing where LimitType comes from, there _still_ seem to be scenarios where the sample as-written passes the wrong type to the log factory delegate. However, I realized we don't need to do any of that anyway, since we can grab the _actual_ instance type from the ParameterInfo.
