### PR TITLE
Corrected to DependsByProp in the registration

### DIFF
--- a/docs/advanced/circular-dependencies.rst
+++ b/docs/advanced/circular-dependencies.rst
@@ -69,7 +69,7 @@ Example:
     var cb = new ContainerBuilder();
     cb.RegisterType<DependsByCtor>()
       .InstancePerLifetimeScope();
-    cb.RegisterType<DependsByProperty>()
+    cb.RegisterType<DependsByProp>()
       .InstancePerLifetimeScope()
       .PropertiesAutowired(PropertyWiringOptions.AllowCircularDependencies);
 


### PR DESCRIPTION
Previously: `cb.RegisterType<DependsByProperty>()`
