### PR TITLE
WithKey is obsolete.

### DIFF
--- a/docs/advanced/keyed-services.rst
+++ b/docs/advanced/keyed-services.rst
@@ -105,7 +105,7 @@ The :doc:`metadata feature of Autofac provides a WithKeyAttribute <metadata>` th
 
     public class ArtDisplay : IDisplay
     {
-      public ArtDisplay([WithKey("Painting")] IArtwork art) { ... }
+      public ArtDisplay([KeyFilter("Painting")] IArtwork art) { ... }
     }
 
 :doc:`See the metadata documentation <metadata>` for more info on how to get this set up.


### PR DESCRIPTION
After installing the `Autofac.Extras.AttributeMetadata` package I discovered the `WithKey` attribute is obsolete and you are pointed to `Use the Autofac.Features.AttributeFilters.KeyFilterAttribute from the core Autofac library instead.`