### PR TITLE
Added info for JSON and XML config assemblies

### DIFF
--- a/docs/configuration/xml.rst
+++ b/docs/configuration/xml.rst
@@ -27,7 +27,7 @@ The basic steps to getting configuration set up with your application are:
 
 1. Set up your configuration in JSON or XML files that can be read by ``Microsoft.Extensions.Configuration``.
   * JSON Configuration uses ``Microsoft.Extensions.Configuration.Json``
-  * XML Configuration uses ``Microsoft.Extensions.Configuration.XML``
+  * XML Configuration uses ``Microsoft.Extensions.Configuration.Xml``
 2. Build the configuration using the ``Microsoft.Extensions.Configuration.ConfigurationBuilder``.
 3. Create a new ``Autofac.Configuration.ConfigurationModule`` and pass the built ``Microsoft.Extensions.Configuration.IConfiguration`` into it.
 4. Register the ``Autofac.Configuration.ConfigurationModule`` with your container.
@@ -85,7 +85,7 @@ Build up your configuration and register it with the Autofac ``ContainerBuilder`
     // Add the configuration to the ConfigurationBuilder.
     var config = new ConfigurationBuilder();
     // config.AddJsonFile comes from Microsoft.Extensions.Configuration.Json
-    // config.AddXmlFile comes from Microsoft.Extensions.Configuration.XML
+    // config.AddXmlFile comes from Microsoft.Extensions.Configuration.Xml
     config.AddJsonFile("autofac.json");
 
     // Register the ConfigurationModule with Autofac.

--- a/docs/configuration/xml.rst
+++ b/docs/configuration/xml.rst
@@ -26,8 +26,8 @@ Quick Start
 The basic steps to getting configuration set up with your application are:
 
 1. Set up your configuration in JSON or XML files that can be read by ``Microsoft.Extensions.Configuration``.
-  * JSON Configuration uses ``Microsoft.Extensions.Configuration.Json``
-  * XML Configuration uses ``Microsoft.Extensions.Configuration.Xml``
+  * JSON configuration uses ``Microsoft.Extensions.Configuration.Json``
+  * XML configuration uses ``Microsoft.Extensions.Configuration.Xml``
 2. Build the configuration using the ``Microsoft.Extensions.Configuration.ConfigurationBuilder``.
 3. Create a new ``Autofac.Configuration.ConfigurationModule`` and pass the built ``Microsoft.Extensions.Configuration.IConfiguration`` into it.
 4. Register the ``Autofac.Configuration.ConfigurationModule`` with your container.

--- a/docs/configuration/xml.rst
+++ b/docs/configuration/xml.rst
@@ -26,6 +26,8 @@ Quick Start
 The basic steps to getting configuration set up with your application are:
 
 1. Set up your configuration in JSON or XML files that can be read by ``Microsoft.Extensions.Configuration``.
+  * JSON Configuration uses ``Microsoft.Extensions.Configuration.Json``
+  * XML Configuration uses ``Microsoft.Extensions.Configuration.XML``
 2. Build the configuration using the ``Microsoft.Extensions.Configuration.ConfigurationBuilder``.
 3. Create a new ``Autofac.Configuration.ConfigurationModule`` and pass the built ``Microsoft.Extensions.Configuration.IConfiguration`` into it.
 4. Register the ``Autofac.Configuration.ConfigurationModule`` with your container.
@@ -82,6 +84,8 @@ Build up your configuration and register it with the Autofac ``ContainerBuilder`
 
     // Add the configuration to the ConfigurationBuilder.
     var config = new ConfigurationBuilder();
+    // config.AddJsonFile comes from Microsoft.Extensions.Configuration.Json
+    // config.AddXmlFile comes from Microsoft.Extensions.Configuration.XML
     config.AddJsonFile("autofac.json");
 
     // Register the ConfigurationModule with Autofac.


### PR DESCRIPTION
The updates to Microsoft.Extensions.Configuration separates JSON and XML assemblies. This update makes it clear where to get the assemblies.