### PR TITLE
Note added to Mulitenant config section

### DIFF
--- a/docs/integration/aspnetcore.rst
+++ b/docs/integration/aspnetcore.rst
@@ -368,6 +368,11 @@ Here's an example of what you do in ``Program.Main``:
       // This is what the middleware will use to create your request lifetime scope.
       public static MultitenantContainer ApplicationContainer { get; set; }
     }
+    
+.. note::
+    By default ASP.NET Core has a void return type for method ``ConfigureServices(IServiceCollection services)``. This needs to be      
+    updated to return the ``IServiceProvider`` type as shown above. 
+    Please refer to the Microsoft `documentation <https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection#replacing-the-default-services-container>`_ about replacing the default container.
 
 
 Using a Child Scope as a Root


### PR DESCRIPTION
Added a note about the ConfigureServices method signature that needs to be changed to enable returning the Autofac service provider. This tripped me up a little because by default its void. Thought it might help newcomers to point to the documentation.