### PR TITLE
Add required service-collection extension method to description for multi-tenancy in ASP.NET Core

### DIFF
--- a/docs/integration/aspnetcore.rst
+++ b/docs/integration/aspnetcore.rst
@@ -313,6 +313,9 @@ Here's an example of what you do in ``Program.Main``:
       {
         // This will all go in the ROOT CONTAINER and is NOT TENANT SPECIFIC.
         services.AddMvc();
+
+        // This adds the required middleware to the ROOT CONTAINER and is required for multitenancy to work.
+        services.AddAutofacMultitenantRequestServices();
       }
 
       public void ConfigureContainer(ContainerBuilder builder)


### PR DESCRIPTION
This adds the missing line that needs to be called in `ConfigureServices(IServiceCollection services)` to register the multitenant-middleware in ASP.NET Core.