### PR TITLE
Added blazor page. Tidied main index description.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ Welcome to Autofac's documentation!
 
 .. image:: logo.png
 
-Autofac is an addictive `IoC container <http://martinfowler.com/articles/injection.html>`_ for Microsoft .NET 4.5, Silverlight 5, Windows Store apps, and Windows Phone 8 apps. It manages the dependencies between classes so that **applications stay easy to change as they grow** in size and complexity. This is achieved by treating regular .NET classes as :doc:`components <glossary>`.
+Autofac is an addictive `IoC container <http://martinfowler.com/articles/injection.html>`_ for .NET. It manages the dependencies between classes so that **applications stay easy to change as they grow** in size and complexity. This is achieved by treating regular .NET classes as :doc:`components <glossary>`.
 
 .. toctree::
    :maxdepth: 3

--- a/docs/integration/blazor.rst
+++ b/docs/integration/blazor.rst
@@ -1,0 +1,39 @@
+============
+Blazor
+============
+
+
+
+`ASP.NET Core Blazor <https://docs.microsoft.com/en-gb/aspnet/core/blazor/>`_ uses the generic app hosting in ASP.NET Core 3+ but the two `hosting models <https://docs.microsoft.com/en-gb/aspnet/core/blazor/hosting-models>`_ have slightly different integrations.
+
+**Server-side** implementations are configured in exactly the same way as any other `ASP.NET Core 3 <aspnetcore>`_ application.
+
+**Client-side** injection is slightly more restricted due to requirements for `WebAssembly <https://webassembly.org>`_ hosting.
+
+At present (as of 11/9/2019), some of the features around ``Startup`` classes are not available: ``ConfiguresServices`` and ``ConfigureContainer`` will not be executed by ``UseBlazorStartup``.
+
+The alternative is to use ``UseServiceProviderFactory`` with an instance of ``AutofacServiceProviderFactory``. The ``AutofacServiceProviderFactory`` takes an ``Action`` on a ``ContainerBuilder`` which can be used for any registrations.
+
+Example:
+
+.. sourcecode:: csharp
+
+  public class Program
+  {
+    public static void Main(string[] args)
+    {
+      CreateHostBuilder(args).Build().Run();
+    }
+
+    public static IWebAssemblyHostBuilder CreateHostBuilder(string[] args) =>
+      BlazorWebAssemblyHost.CreateDefaultBuilder()
+        .UseServiceProviderFactory(new AutofacServiceProviderFactory(Register))
+        .UseBlazorStartup<Startup>();
+
+    private static void Register(ContainerBuilder builder)
+    {
+      // add any registrations here
+    }
+  }
+
+Once registered, Blazor components can use `dependency injection <https://docs.microsoft.com/en-gb/aspnet/core/blazor/dependency-injection>`_ via the `standard @inject Razor directive <https://docs.microsoft.com/en-us/aspnet/core/blazor/dependency-injection?view=aspnetcore-3.0#request-a-service-in-a-component>`_.

--- a/docs/integration/index.rst
+++ b/docs/integration/index.rst
@@ -7,6 +7,7 @@ Application Integration
     aspnet.rst
     netcore.rst
     aspnetcore.rst
+    blazor.rst
     wcf.rst
     servicefabric.rst
     mef.rst


### PR DESCRIPTION
I've added a new page with basic instructions covering the complications for client-side DI in Blazor as per #1025. It should potentially be part of the ASP.NET Core page but that seems to be getting a little bloated - maybe it's worth considering splitting that down soon, similar to the ASP.NET section?

I also noticed the somewhat outdated description for general Autofac target frameworks on the main index page, which looks a little odd, so I've snuck in a small update for that here too.