### PR TITLE
Removed empty syntax highlight block from documentation.

### DIFF
--- a/docs/configuration/modules.rst
+++ b/docs/configuration/modules.rst
@@ -126,8 +126,6 @@ It is a 'best practice' when using Autofac to add any XML configuration *after* 
 
 In this way, 'emergency' overrides can be made in :doc:`a configuration file <xml>`:
 
-.. sourcecode:: xml
-
 .. sourcecode:: json
 
     {


### PR DESCRIPTION
Removed empty syntax highlight block from modules documentation.
Before:
<img width="727" alt="Skärmavbild 2020-01-26 kl  11 49 39" src="https://user-images.githubusercontent.com/2316544/73134062-1b5f6300-4032-11ea-875a-86e04eb58009.png">
After:
<img width="729" alt="Skärmavbild 2020-01-26 kl  11 49 56" src="https://user-images.githubusercontent.com/2316544/73134064-20bcad80-4032-11ea-896d-8b9aae3ba045.png">

