### PR TITLE
Update Moq Integration docs now that Provide has been removed.

### DIFF
--- a/docs/integration/moq.rst
+++ b/docs/integration/moq.rst
@@ -90,8 +90,8 @@ Configuring Specific Dependencies
 =================================
 
 You can configure the ``AutoMock`` to provide a specific instance for a given service type (or apply any other registration behaviour),
-by using the ``beforeBuild`` callback argument to GetLoose, GetStrict or GetFromRepository, in the same way as if you 
-were configuring a new Lifetime Scope:
+by using the ``beforeBuild`` callback argument to ``GetLoose``, ``GetStrict`` or ``GetFromRepository``, in a similar manner
+to configuring a new Lifetime Scope:
 
 .. sourcecode:: csharp
 


### PR DESCRIPTION
Remove references to Provide, reword for using the configuration callback, and give new examples.

Fixes #99