### PR TITLE
IWebHostingEnvironment to IWebHostEnvironment

### DIFF
--- a/docs/integration/aspnetcore.rst
+++ b/docs/integration/aspnetcore.rst
@@ -152,7 +152,7 @@ In your Startup class (which is basically the same across all the versions of AS
     {
       public Startup(IHostingEnvironment env)
       {
-        // In ASP.NET Core 3.0 `env` will be an IWebHostingEnvironment, not IHostingEnvironment.
+        // In ASP.NET Core 3.0 `env` will be an IWebHostEnvironment, not IHostingEnvironment.
         var builder = new ConfigurationBuilder()
             .SetBasePath(env.ContentRootPath)
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)


### PR DESCRIPTION
There is no such interface `IWebHostingEnvironment`. The recommended interface in this case should be [IWebHostEnvironment](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.hosting.iwebhostenvironment?view=aspnetcore-3.1).

Check out this startup class example from the [Microsoft documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/startup?view=aspnetcore-3.1).