### PR TITLE
Clarify use of Populate() with ASP.NET Core 3.0+

### DIFF
--- a/docs/integration/aspnetcore.rst
+++ b/docs/integration/aspnetcore.rst
@@ -201,6 +201,9 @@ In your Startup class (which is basically the same across all the versions of AS
         app.UseMvc();
       }
     }
+No need to call Populate()
+--------------------------
+The new ``AutofacServiceProvider`` for ASP.NET Core 3.0 takes care of calling ``builder.Populate(services);`` on your behalf.  This means that you can still take advantage of, e.g. the new `IHttpClientFactory <https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests>`_ that relies heavily on Microsoft DI for configuring ``HttpClient`` instances.
 
 Configuration Method Naming Conventions
 =======================================


### PR DESCRIPTION
I spent a while trying to understand how to use IHttpClientFactory (and Polly) with ASP.NET Core 3.0.  It's now obvious to me that it's not an issue given the new AutofacServiceProvider.  I thought it would be worth clarifying this to save other people's time.