### PR TITLE
Update the signature of the example IRegistrationSource

### DIFF
--- a/docs/advanced/registration-sources.rst
+++ b/docs/advanced/registration-sources.rst
@@ -125,7 +125,7 @@ Here's the code for the registration source.
     {
       public IEnumerable<IComponentRegistration> RegistrationsFor(
         Service service,
-        Func<Service, IEnumerable<IComponentRegistration>> registrationAccessor)
+        Func<Service, IEnumerable<ServiceRegistration>> registrationAccessor)
       {
         var swt = service as IServiceWithType;
         if(swt == null || !typeof(BaseHandler).IsAssignableFrom(swt.ServiceType))


### PR DESCRIPTION
I think this is the only change needed to fix #112.

The existing docs don't go into too much depth on how to use the parameters on `RegistrationsFor`, which I think is basically ok.