### PR TITLE
Add example for RegistrationData events migration to 6.x

### DIFF
--- a/docs/advanced/pipelines.rst
+++ b/docs/advanced/pipelines.rst
@@ -158,7 +158,7 @@ in the same way you would have added other shared registration behaviour:
     {
         // The PipelineBuilding event fires just before the pipeline is built, and 
         // middleware can be added inside it.
-        args.ComponentRegistration.PipelineBuilding += (sender, pipeline) =>
+        args.ComponentRegistration.PipelineBuilding += (sender2 , pipeline) =>
         {
             pipeline.Use(new MyCustomMiddleware());
         };

--- a/docs/whats-new/upgradingfrom5to6.rst
+++ b/docs/whats-new/upgradingfrom5to6.rst
@@ -63,6 +63,38 @@ that most users shouldn't run into.
   no longer exposes ``Preparing``, ``Activating`` or ``Activated`` events.
   
   All Autofac events are now implemented as ``CoreEventMiddleware`` added to the resolve pipeline.
+ 
+  .. code-block:: csharp
+
+     // 5.x
+     builder.RegisterCallback(x =>
+     {
+         x.Registered += (sender, args) =>
+         {
+             args.ComponentRegistration.Activated += (o, c) =>
+             {
+                 // Do something with the component instance
+                 var instance = c.Instance;
+             };
+         };
+     });
+     
+     // 6.x
+     builder.ComponentRegistryBuilder.Registered += (sender, args) =>
+     {
+         args.ComponentRegistration.PipelineBuilding += (sender2, pipeline) =>
+         {
+             pipeline.Use(PipelinePhase.Activation, MiddlewareInsertionMode.EndOfPhase, (c, next) =>
+             {
+                 next(c);
+                 
+                 // Do something with the component instance
+                 var instance = c.Instance;
+                 
+             });
+         };
+     };
+  
 
   If you need to inspect the set of event handlers added to the registration, you can inspect the registered middleware for instances of ``CoreEventMiddleware``:
 


### PR DESCRIPTION
1. Fix compilation of the example because of:

```
A local or parameter named 'sender' cannot be declared in this scope because that name is used in an enclosing local scope to 
define a local or parameter
```

2. Add example to the migration section. I'm not sure if that's the right replacement for ` args.ComponentRegistration.Activated += (o, c)` however it works correctly.