### PR TITLE
Resolve #115: Add ContravariantRegistrationSource docs.

### DIFF
--- a/docs/advanced/registration-sources.rst
+++ b/docs/advanced/registration-sources.rst
@@ -31,29 +31,32 @@ The ``ContravariantRegistrationSource`` is helpful in registering types that nee
       void Handle(TCommand command);
     }
 
-    public class CommandAHandler : IHandler<CommandA>
+    public class BaseCommandHandler : IHandler<BaseCommand>
     {
-      public void Handle(CommandA command)
+      public void Handle(BaseCommand command)
       {
+         Console.WriteLine(command.GetType().Name);
       }
     }
 
-    public class CommandA
+    public class BaseCommand
     {
     }
 
-    public class CommandB : CommandA
+    public class DerivedCommand : BaseCommand
     {
     }
 
     var builder = new ContainerBuilder();
     builder.RegisterSource(new ContravariantRegistrationSource());
-    builder.RegisterType<CommandAHandler>().As<IHandler<CommandA>>();
+    builder.RegisterType<BaseCommandHandler>().As<IHandler<BaseCommand>>();
     var container = builder.Build();
 
-    // a and b are both CommandAHandler.
-    var a = container.Resolve<IHandler<CommandA>>();
-    var b = container.Resolve<IHandler<CommandB>>();
+    // a and b are both BaseCommandHandler.
+    var a = container.Resolve<IHandler<BaseCommand>>();
+    a.Handle(new BaseCommand()); // prints BaseCommand
+    var b = container.Resolve<IHandler<DerivedCommand>>();
+    b.Handle(new DerivedCommand()); // prints DerivedCommand
 
 
 Implementing a Registration Source

--- a/docs/advanced/registration-sources.rst
+++ b/docs/advanced/registration-sources.rst
@@ -20,6 +20,42 @@ You can use the ``Autofac.Features.ResolveAnything.AnyConcreteTypeNotAlreadyRegi
     builder.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource());
     var container = builder.Build();
 
+Contravariant Registration Source
+=================================
+The ``ContravariantRegistrationSource`` is helpful in registering types that need to be later resolved in a `contravariant context <https://docs.microsoft.com/en-us/dotnet/standard/generics/covariance-and-contravariance>`_ (using a more generic / less derived type than originally specified). This is common in handler patterns:
+
+.. sourcecode:: csharp
+
+    public interface IHandler<in TCommand>
+    {
+      void Handle(TCommand command);
+    }
+
+    public class CommandAHandler : IHandler<CommandA>
+    {
+      public void Handle(CommandA command)
+      {
+      }
+    }
+
+    public class CommandA
+    {
+    }
+
+    public class CommandB : CommandA
+    {
+    }
+
+    var builder = new ContainerBuilder();
+    builder.RegisterSource(new ContravariantRegistrationSource());
+    builder.RegisterType<CommandAHandler>().As<IHandler<CommandA>>();
+    var container = builder.Build();
+
+    // a and b are both CommandAHandler.
+    var a = container.Resolve<IHandler<CommandA>>();
+    var b = container.Resolve<IHandler<CommandB>>();
+
+
 Implementing a Registration Source
 ==================================
 


### PR DESCRIPTION
Resolves #115. Adds docs to the registration source page to discuss the contravariant registration source.

I'll admit sometimes I get confused with covariance vs. contravariance, too, so double-check my example. I tried to simplify the [tests for `ContravariantRegistrationSource`](https://github.com/autofac/Autofac/blob/master/test/Autofac.Test/Features/Variance/ContravariantRegistrationSourceTests.cs) down to something digestible but admittedly didn't run the whole thing through a compiler or anything.