### PR TITLE
Add documentation for Lambda Generic Registrations, and fix async disposal docs issue

### DIFF
--- a/docs/advanced/debugging.rst
+++ b/docs/advanced/debugging.rst
@@ -24,6 +24,8 @@ Also, take a look at your exception stack traces. It may look like Autofac is th
 
 And, of course, if you're hitting that ever-challenging ``No scope with a Tag matching 'AutofacWebRequest'`` exception, :doc:`we have a whole FAQ on that <../faq/per-request-scope>`.
 
+.. _debugging_diagnostics:
+
 Diagnostics
 -----------
 

--- a/docs/lifetime/disposal.rst
+++ b/docs/lifetime/disposal.rst
@@ -100,7 +100,12 @@ When using Autofac with the ASP.NET Core Integration, all per-request lifetime s
   recommend you do so.
 
   If your component only implements ``IAsyncDisposable``, but someone disposes of the scope synchronously,
-  then Autofac will throw an exception, because it does not know how to dispose of your component.
+  then Autofac will be forced to use a sync-over-async blocking dispose, and will raise a :ref:`diagnostic warning <_debugging_diagnostics>`:
+
+  ```
+  AUTOFAC: A synchronous Dispose has been attempted, but the tracked object of type 'AsyncComponent' only implements IAsyncDisposable.
+  This will result in an inefficient blocking dispose. Consider either implementing IDisposable on 'AsyncComponent or disposing of the scope/container with DisposeAsync.
+  ```
 
 Specified Disposal
 ------------------

--- a/docs/lifetime/disposal.rst
+++ b/docs/lifetime/disposal.rst
@@ -100,12 +100,11 @@ When using Autofac with the ASP.NET Core Integration, all per-request lifetime s
   recommend you do so.
 
   If your component only implements ``IAsyncDisposable``, but someone disposes of the scope synchronously,
-  then Autofac will be forced to use a sync-over-async blocking dispose, and will raise a :ref:`diagnostic warning <_debugging_diagnostics>`:
+  then Autofac will be forced to use a sync-over-async blocking dispose, and will raise a :ref:`diagnostic warning <debugging_diagnostics>`:
 
-  ```
-  AUTOFAC: A synchronous Dispose has been attempted, but the tracked object of type 'AsyncComponent' only implements IAsyncDisposable.
-  This will result in an inefficient blocking dispose. Consider either implementing IDisposable on 'AsyncComponent or disposing of the scope/container with DisposeAsync.
-  ```
+    AUTOFAC: A synchronous Dispose has been attempted, but the tracked object of type 'AsyncComponent' only implements IAsyncDisposable.
+    This will result in an inefficient blocking dispose. Consider either implementing IDisposable on 'AsyncComponent' or disposing of the
+    scope/container with DisposeAsync.
 
 Specified Disposal
 ------------------

--- a/docs/register/parameters.rst
+++ b/docs/register/parameters.rst
@@ -69,7 +69,14 @@ Parameters with Lambda Expression Components
 
 With lambda expression component registrations, rather than passing the parameter value *at registration time* you enable the ability to pass the value *at service resolution time*. (:doc:`Read more about resolving with parameters. <../resolve/parameters>`)
 
-In the component registration expression, you can make use of the incoming parameters by changing the delegate signature you use for registration. Instead of just taking in an ``IComponentContext`` parameter, take in an ``IComponentContext`` and an ``IEnumerable<Parameter>``:
+In the component registration expression, you can make use of the incoming parameters by using the generic lambda ``Register`` methods:
+
+.. sourcecode:: csharp
+
+    builder.Register((string configSectionName) => new ConfigReader(configSectionName));
+
+If you need access to the full list of parameters, it's available by changing the delegate signature you use for registration.
+Instead of specifying the parameter as an argument to the lambda, take in an ``IComponentContext`` and an ``IEnumerable<Parameter>``:
 
 .. sourcecode:: csharp
 

--- a/docs/register/parameters.rst
+++ b/docs/register/parameters.rst
@@ -73,7 +73,7 @@ In the component registration expression, you can make use of the incoming param
 
 .. sourcecode:: csharp
 
-    builder.Register((string configSectionName) => new ConfigReader(configSectionName));
+    builder.Register((MyConfig config) => new Worker(config));
 
 If you need access to the full list of parameters, it's available by changing the delegate signature you use for registration.
 Instead of specifying the parameter as an argument to the lambda, take in an ``IComponentContext`` and an ``IEnumerable<Parameter>``:
@@ -84,11 +84,15 @@ Instead of specifying the parameter as an argument to the lambda, take in an ``I
     // c = The current IComponentContext to dynamically resolve dependencies
     // p = An IEnumerable<Parameter> with the incoming parameter set
     builder.Register((c, p) =>
-                     new ConfigReader(p.Named<string>("configSectionName")))
-           .As<IConfigReader>();
+                     new Worker(p.Named<MyConfig>(config)));
 
 When :doc:`resolving with parameters <../resolve/parameters>`, your lambda will use the parameters passed in:
 
 .. sourcecode:: csharp
 
-    var reader = scope.Resolve<IConfigReader>(new NamedParameter("configSectionName", "sectionName"));
+    var customConfig = new MyConfig
+    {
+      SomeValue = "../"
+    };
+
+    var reader = scope.Resolve<MyConfig>(new NamedParameter(config, customConfig));

--- a/docs/register/registration.rst
+++ b/docs/register/registration.rst
@@ -134,7 +134,7 @@ Autofac can accept a delegate or lambda expression to be used as a component cre
 
 .. sourcecode:: csharp
 
-  builder.Register(c => new A(c.Resolve<B>()));
+    builder.Register(c => new A(c.Resolve<B>()));
 
 The parameter ``c`` provided to the expression is the *component context* (an ``IComponentContext`` object) in which the component is being created. You can use this to resolve other values from the container to assist in creating your component. **It is important to use this rather than a closure to access the container** so that :doc:`deterministic disposal <../lifetime/disposal>` and nested containers can be supported correctly.
 
@@ -144,13 +144,13 @@ As well as using ``IComponentContext`` to resolve dependencies in your lambda ex
 
 .. sourcecode:: csharp
 
-  builder.Register((IDependency1 dep1, IDependency2 dep2) => new Component(dep1, dep2));
+    builder.Register((IDependency1 dep1, IDependency2 dep2) => new Component(dep1, dep2));
 
-You can blend the ``IComponentContext`` and generic approach if you need to make conditional choices, or use methods like ``ResolveNamed``:
+You can blend the ``IComponentContext`` and generic approach if you need to make conditional choices, or use methods like ``ResolveNamed``. Just add the ``IComponentContext`` as the first parameter to the lambda:
 
 .. sourcecode:: csharp
 
-  builder.Register((IComponentContext ctxt, IDependency1 dep1) => new Component(dep1, ctxt.ResolveNamed<IDependency2>("value")));
+    builder.Register((IComponentContext ctxt, IDependency1 dep1) => new Component(dep1, ctxt.ResolveNamed<IDependency2>("value")));
 
 The default service provided by an expression-created component is the inferred return type of the expression.
 

--- a/docs/register/registration.rst
+++ b/docs/register/registration.rst
@@ -140,6 +140,18 @@ The parameter ``c`` provided to the expression is the *component context* (an ``
 
 Additional dependencies can be satisfied using this context parameter - in the example, ``A`` requires a constructor parameter of type ``B`` that may have additional dependencies.
 
+As well as using ``IComponentContext`` to resolve dependencies in your lambda expression, you can also use the generic ``Register`` overloads to specify your dependencies as a variable number of typed arguments to the lambda, and Autofac will resolve them for you:
+
+.. sourcecode:: csharp
+
+  builder.Register((IDependency1 dep1, IDependency2 dep2) => new Component(dep1, dep2));
+
+You can blend the ``IComponentContext`` and generic approach if you need to make conditional choices, or use methods like ``ResolveNamed``:
+
+.. sourcecode:: csharp
+
+  builder.Register((IComponentContext ctxt, IDependency1 dep1) => new Component(dep1, ctxt.ResolveNamed<IDependency2>("value")));
+
 The default service provided by an expression-created component is the inferred return type of the expression.
 
 Below are some examples of requirements met poorly by reflective component creation but nicely addressed by lambda expressions.


### PR DESCRIPTION
I decided to stick with talking about the original `IComponentContext` variant first, then introducing the new alternative.

Probably best to hold off merging this until we push the next Autofac release.

Also fixed #154 