### PR TITLE
Refer to TypedParameter extension method

### DIFF
--- a/docs/register/parameters.rst
+++ b/docs/register/parameters.rst
@@ -56,7 +56,7 @@ Or you could pass a parameter to a reflection component registration:
     // Using a TYPED parameter:
     builder.RegisterType<ConfigReader>()
            .As<IConfigReader>()
-           .WithParameter(new TypedParameter(typeof(string), "sectionName"));
+           .WithParameter(TypedParameter.From("sectionName"));
 
     // Using a RESOLVED parameter:
     builder.RegisterType<ConfigReader>()


### PR DESCRIPTION
This is a more elegant method of specifying typed parameters