### PR TITLE
Remove obsolete VersionPrefix from placeholder csproj

### DIFF
--- a/build-apidoc/Placeholder/Placeholder.csproj
+++ b/build-apidoc/Placeholder/Placeholder.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;net10.0</TargetFrameworks>
-    <VersionPrefix>0.0.1</VersionPrefix>
     <Authors>Autofac Contributors</Authors>
     <Company>Autofac</Company>
     <Product>Autofac</Product>


### PR DESCRIPTION
## Summary
- Removes the `<VersionPrefix>` property from the placeholder .csproj used for API doc generation
- Version is set by `default.proj` via `/p:Version` during GitHub Actions CI, making the csproj entry unnecessary

## Test plan
- [ ] CI build passes
- [ ] API doc generation still works correctly