### PR TITLE
Document Service Fabric interception, scoping, and package versioning

### DIFF
--- a/docs/integration/servicefabric.rst
+++ b/docs/integration/servicefabric.rst
@@ -68,6 +68,86 @@ In your ``Main`` program method, build up your container and register services u
       }
     }
 
+Registration Requirements
+=========================
+
+Registered service and actor types are wrapped in a dynamic proxy so the integration can dispose the service's lifetime scope when Service Fabric closes or aborts the service. That places some requirements on the types you register:
+
+* The type must be a class, and it must not be ``sealed`` or ``abstract``.
+* Only ``virtual`` members can be intercepted.
+* The type must be visible to the proxy generator - see below if your service types are ``internal``.
+
+Internal Service Types
+----------------------
+
+Castle DynamicProxy generates proxies into an assembly named ``DynamicProxyGenAssembly2``, so an ``internal`` service or actor type has to grant that assembly access to its internals. Without it you'll see an error like ``Access is denied: 'MyNamespace.MyService'``.
+
+Which form of the attribute you need depends on whether **your** assembly is strong named. Castle only signs the generated assembly when the assembly containing the proxied type is itself signed.
+
+If your assembly is strong named, use the constant from ``Castle.Core.Internal``, which includes Castle's public key:
+
+.. sourcecode:: csharp
+
+    using System.Runtime.CompilerServices;
+    using Castle.Core.Internal;
+
+    [assembly: InternalsVisibleTo(InternalsVisible.ToDynamicProxyGenAssembly2)]
+
+If your assembly is *not* strong named, name the assembly without a public key:
+
+.. sourcecode:: csharp
+
+    using System.Runtime.CompilerServices;
+
+    [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+
+.. note::
+
+   Using the keyed form from an unsigned assembly is the usual cause of ``Access is denied``. The public key in the attribute won't match the unsigned generated assembly, so the grant doesn't apply. This is unrelated to whether the ``Autofac.ServiceFabric`` package is signed.
+
+Service and Actor Lifetime Scopes
+=================================
+
+When Service Fabric creates a service or actor, the integration creates a child lifetime scope for it, tagged ``ServiceFabric`` by default, and resolves the instance from that scope. The scope is disposed when the service is closed or aborted.
+
+The context objects that Service Fabric supplies are registered into that child scope rather than into the root container. That includes ``ServiceContext`` and its ``StatelessServiceContext`` / ``StatefulServiceContext`` forms, along with ``ActorService`` and ``ActorId`` for actors.
+
+This has an important consequence: **a component that depends on ``ServiceContext`` cannot be registered as ``SingleInstance()``**. A single instance component is rooted in the container, where those context registrations don't exist, so resolving it fails with ``The requested service 'System.Fabric.ServiceContext' has not been registered``. Injecting ``Lazy<T>`` or ``Func<T>`` doesn't help, because the problem is where the component lives, not when it's created.
+
+Register such components against the service scope instead:
+
+.. sourcecode:: csharp
+
+    // This fails at resolve time - the root container has no ServiceContext.
+    builder.RegisterType<TelemetryLogger>()
+      .As<ILogger>()
+      .SingleInstance();
+
+    // This works, and gives you one instance per service or actor.
+    builder.RegisterType<TelemetryLogger>()
+      .As<ILogger>()
+      .InstancePerMatchingLifetimeScope("ServiceFabric");
+
+If you passed a custom ``lifetimeScopeTag`` when registering the service, match that tag instead of ``"ServiceFabric"``.
+
+Adding Registrations to the Service Scope
+-----------------------------------------
+
+Some components can only be built once the ``ServiceContext`` exists, which means they have to be registered while the service scope is being created. ``RegisterServiceFabricSupport`` takes a ``configurationAction`` for this - it runs during creation of every service and actor scope, after the context objects have been registered.
+
+The Application Insights ``FabricTelemetryInitializer`` is the canonical example, since it needs the ``ServiceContext`` to be constructed:
+
+.. sourcecode:: csharp
+
+    builder.RegisterServiceFabricSupport(
+      configurationAction: b =>
+        b.Register(c => FabricTelemetryInitializerExtension.CreateFabricTelemetryInitializer(
+            c.Resolve<ServiceContext>()))
+          .As<ITelemetryInitializer>()
+          .SingleInstance());
+
+Resolve the context from the ``IComponentContext`` passed to the registration delegate, as shown, rather than capturing it - the instance is registered just before the action runs, while the scope is still being built.
+
 Per-Request Scopes
 ==================
 
@@ -99,7 +179,17 @@ For example, say you have a user service that is stateless and it needs to read 
 
 While there's no "built in" semantics around per-request handling specifically, you can do a lot with the :doc:`implicit relationships <../resolve/relationships>` so it's worth becoming familiar with them.
 
-Example
-=======
+Service Fabric Package Versions
+===============================
 
-There is an example project showing Service Fabric integration `in the Autofac examples repository <https://github.com/autofac/Examples/tree/master/src/ServiceFabricDemo>`_.
+The ``Microsoft.ServiceFabric.*`` packages pin each other to exact versions. ``Microsoft.ServiceFabric.Actors``, for example, requires an exact match of ``Microsoft.ServiceFabric.Services.Remoting``, which in turn requires exact matches of its own dependencies, all the way down to the ``Microsoft.ServiceFabric`` runtime package.
+
+Because ``Autofac.ServiceFabric`` references those packages, the version it was built against effectively sets the Service Fabric package version for your project. Referencing a different version of any individual Service Fabric package will produce ``NU1608`` warnings:
+
+.. sourcecode:: text
+
+    warning NU1608: Detected package version outside of dependency constraint:
+    Microsoft.ServiceFabric.Actors 8.6.239 requires Microsoft.ServiceFabric.Data (= 8.6.239)
+    but version Microsoft.ServiceFabric.Data 8.5.216 was resolved.
+
+Reference the Service Fabric packages you use explicitly, and keep them all on the same version as the one ``Autofac.ServiceFabric`` depends on. This is a consequence of how Microsoft versions those packages, so it isn't something the Autofac integration can work around on your behalf.


### PR DESCRIPTION
Fixes #187.

Three long-standing issues on the [Autofac.ServiceFabric](https://github.com/autofac/Autofac.ServiceFabric) repo turned out to be documentation gaps rather than code defects. They're being closed in favor of #187, and this covers them.

## What's added

**Registration Requirements** — the page never mentioned that every registered service and actor type is wrapped in a dynamic proxy, or what that requires (class, not `sealed`/`abstract`, only `virtual` members intercepted). Those constraints only existed in API XML docs.

**Internal Service Types** — resolves [Autofac.ServiceFabric#49](https://github.com/autofac/Autofac.ServiceFabric/issues/49). An internal service type needs `InternalsVisibleTo` for `DynamicProxyGenAssembly2`, and **which form depends on whether the consumer's own assembly is strong named**, because Castle only signs its generated assembly when the assembly holding the proxied type is signed. Using the keyed `Castle.Core.Internal` constant from an unsigned assembly is what produces `Access is denied` — a genuinely misleading error for the actual cause. Added a note saying so explicitly, since people reasonably assume it's about whether `Autofac.ServiceFabric` is signed.

**Service and Actor Lifetime Scopes** — resolves [Autofac.ServiceFabric#51](https://github.com/autofac/Autofac.ServiceFabric/issues/51). Documents that the SF context objects are registered into the per-replica child scope, not the root container, and therefore that a component depending on `ServiceContext` can't be `SingleInstance()`. Shows the failing registration next to the `InstancePerMatchingLifetimeScope("ServiceFabric")` fix. Also notes that `Lazy<T>`/`Func<T>` don't help, since that's what the reporter tried first.

**Adding Registrations to the Service Scope** — documents the `configurationAction` parameter of `RegisterServiceFabricSupport`, which shipped in v4.0.0 and was never documented. Uses the Application Insights `FabricTelemetryInitializer` example from [Autofac.ServiceFabric#57](https://github.com/autofac/Autofac.ServiceFabric/issues/57), which is the scenario it was built for.

**Service Fabric Package Versions** — resolves [Autofac.ServiceFabric#18](https://github.com/autofac/Autofac.ServiceFabric/issues/18), open since 2017. The `Microsoft.ServiceFabric.*` packages pin each other to exact versions, so the version `Autofac.ServiceFabric` depends on effectively sets the SF package version for the whole consuming project. Mixing versions yields `NU1608`. Documented as guidance because it's inherent to Microsoft's versioning and the integration can't work around it.

## What's removed

The **Example** section. It linked to `autofac/Examples/tree/master/src/ServiceFabricDemo`, and that directory was deleted from the Examples repo — on a branch that has since been renamed from `master` to `main`, so the link was dead twice over. Rather than leave a broken link or replace it with meta-commentary about missing content, the section is gone; it should be restored when a current sample lands (tracked separately in the Examples repo).

## Deliberately not included

The `constructorExceptionCallback` signature change from [Autofac.ServiceFabric#47](https://github.com/autofac/Autofac.ServiceFabric/issues/47) is unreleased, so documenting it now would describe API that isn't on NuGet yet. That belongs with the next release.

## Verification

`doc8` clean, and a full `sphinx -b html` build succeeds with every new section rendering correctly. The only build warnings are two pre-existing `unknown document: '../troubleshooting/diagnostics'` references in `faq/container-analysis.rst` and `lifetime/disposal.rst`, unrelated to this change.