### PR TITLE
Update Service Fabric version guidance for the lowered dependency floor

### DIFF
--- a/docs/integration/servicefabric.rst
+++ b/docs/integration/servicefabric.rst
@@ -184,7 +184,9 @@ Service Fabric Package Versions
 
 The ``Microsoft.ServiceFabric.*`` packages pin each other to exact versions. ``Microsoft.ServiceFabric.Actors``, for example, requires an exact match of ``Microsoft.ServiceFabric.Services.Remoting``, which in turn requires exact matches of its own dependencies, all the way down to the ``Microsoft.ServiceFabric`` runtime package.
 
-Because ``Autofac.ServiceFabric`` references those packages, the version it was built against effectively sets the Service Fabric package version for your project. Referencing a different version of any individual Service Fabric package will produce ``NU1608`` warnings:
+To keep that from dictating your Service Fabric version, ``Autofac.ServiceFabric`` references the *oldest* Service Fabric SDK it supports rather than the newest. NuGet treats package references as minimums, so your own Service Fabric version wins and you're free to use any newer SDK without waiting for a new release of the integration.
+
+What this does mean is that you should **reference the Service Fabric packages you use explicitly, and keep them consistent with each other**. Mixing versions among your own Service Fabric references is what produces ``NU1608``:
 
 .. sourcecode:: text
 
@@ -192,4 +194,8 @@ Because ``Autofac.ServiceFabric`` references those packages, the version it was 
     Microsoft.ServiceFabric.Actors 8.6.239 requires Microsoft.ServiceFabric.Data (= 8.6.239)
     but version Microsoft.ServiceFabric.Data 8.5.216 was resolved.
 
-Reference the Service Fabric packages you use explicitly, and keep them all on the same version as the one ``Autofac.ServiceFabric`` depends on. This is a consequence of how Microsoft versions those packages, so it isn't something the Autofac integration can work around on your behalf.
+If you don't reference the Service Fabric packages yourself, you'll silently get the oldest supported versions, which probably isn't what you want. The Service Fabric project templates add these references for you.
+
+.. note::
+
+   Building against an older SDK than you run against is expected and supported here - the Service Fabric assemblies keep the same assembly version across package releases, so there's no binding difference. Microsoft documents the SDK as backwards compatible, and which SDK versions pair with which cluster runtime is listed in the `Service Fabric versions <https://learn.microsoft.com/azure/service-fabric/service-fabric-versions>`_ reference.


### PR DESCRIPTION
Follow-up to #188. **Merge this with the Autofac.ServiceFabric 5.0.0 release, not before** — it describes behavior that ships in autofac/Autofac.ServiceFabric#71.

## Why

#188 told consumers to keep their Service Fabric packages "on the same version as the one `Autofac.ServiceFabric` depends on." That was accurate at the time, but autofac/Autofac.ServiceFabric#71 lowers the integration's dependency floor to the oldest supported SDK precisely so consumers *aren't* pinned to our version. The old advice becomes wrong.

## What changed

- Consumers choose their own Service Fabric version; the integration floors at the oldest supported SDK and NuGet lets the higher version win.
- The thing they actually need to do is keep **their own** Service Fabric references consistent with each other — that's what produces `NU1608`. The example warning is kept, since it's still exactly what a mismatch looks like.
- Added the consequence of not referencing the Service Fabric packages at all: you silently get the oldest supported versions. Also noted the project templates add them for you.
- Added a note that building against an older SDK than you run against is expected, because the Service Fabric assemblies keep a stable assembly version across package releases, with a link to Microsoft's SDK/runtime pairing table.

## Verification

`doc8` clean. Full `sphinx -b html` build succeeds and the new content renders. The only warnings are the two pre-existing `unknown document: '../troubleshooting/diagnostics'` references in `faq/container-analysis.rst` and `lifetime/disposal.rst`.