### PR TITLE
Refresh API doc build for the current release

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -5,7 +5,7 @@
       "commands": [
         "docfx"
       ],
-      "version": "2.77.0"
+      "version": "2.78.5"
     }
   },
   "version": 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,8 @@ The `Placeholder` project in `build-apidoc/` holds NuGet references to the vario
 ### Adding/Updating Doc Sources
 
 1. Update the NuGet package version in `build-apidoc/Placeholder/Placeholder.csproj`.
-2. The `Microsoft.NETFramework.ReferenceAssemblies.net472` package enables cross-platform compilation, so you can build on Windows, macOS, or Linux.
-3. Add package references under the framework-specific item group that matches compatibility (`net10.0` for modern packages, `net472` for legacy ASP.NET/.NET Framework integrations).
+2. The `Microsoft.NETFramework.ReferenceAssemblies` package enables cross-platform compilation, so you can build on Windows, macOS, or Linux.
+3. Add package references under the framework-specific item group that matches compatibility (`net10.0` for modern packages, `net481` for legacy ASP.NET/.NET Framework integrations).
 4. Ensure target packages have XML documentation files (most Autofac packages do).
 
 ### Building the Documentation
@@ -130,7 +130,7 @@ This will:
 
 1. Restore .NET tools (including `docfx`)
 2. Clean previous build artifacts
-3. Restore NuGet packages and build API metadata for both `net10.0` and `net472`
+3. Restore NuGet packages and build API metadata for both `net10.0` and `net481`
 4. Merge metadata into one logical DocFX output
 5. Generate HTML documentation
 

--- a/build-apidoc/Documentation.proj
+++ b/build-apidoc/Documentation.proj
@@ -9,7 +9,7 @@
 
     <!-- Build both framework-specific assembly sets that DocFX reads -->
     <Exec Command="dotnet build -f net10.0" WorkingDirectory="$(MSBuildProjectDirectory)/Placeholder" />
-    <Exec Command="dotnet build -f net472" WorkingDirectory="$(MSBuildProjectDirectory)/Placeholder" />
+    <Exec Command="dotnet build -f net481" WorkingDirectory="$(MSBuildProjectDirectory)/Placeholder" />
 
     <!-- Build API documentation using DocFX -->
     <Exec Command="dotnet docfx build-apidoc/docfx.json" WorkingDirectory="$(MSBuildProjectDirectory)/.." />

--- a/build-apidoc/Placeholder/Placeholder.csproj
+++ b/build-apidoc/Placeholder/Placeholder.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net10.0</TargetFrameworks>
+    <TargetFrameworks>net481;net10.0</TargetFrameworks>
     <Authors>Autofac Contributors</Authors>
     <Company>Autofac</Company>
     <Product>Autofac</Product>
@@ -10,24 +10,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.1.0" />
+    <PackageReference Include="Autofac" Version="9.3.2" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <!-- Enable cross-platform compilation of net472 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net481'">
+    <!-- Enable cross-platform compilation of net481 -->
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
 
     <!-- .NET Framework-specific integrations -->
-    <PackageReference Include="Autofac.Multitenant.Wcf" Version="6.0.0" />
-    <PackageReference Include="Autofac.Mvc5" Version="6.1.0" />
-    <PackageReference Include="Autofac.Mvc5.Owin" Version="6.1.0" />
-    <PackageReference Include="Autofac.Owin" Version="7.1.0" />
-    <PackageReference Include="Autofac.ServiceFabric" Version="4.0.0" />
-    <PackageReference Include="Autofac.SignalR2" Version="6.1.0" />
-    <PackageReference Include="Autofac.Wcf" Version="7.0.0" />
-    <PackageReference Include="Autofac.Web" Version="7.0.0" />
-    <PackageReference Include="Autofac.WebApi2" Version="6.2.0" />
-    <PackageReference Include="Autofac.WebApi2.Owin" Version="6.2.1" />
+    <PackageReference Include="Autofac.Multitenant.Wcf" Version="7.0.0" />
+    <PackageReference Include="Autofac.Mvc5" Version="7.0.0" />
+    <PackageReference Include="Autofac.Mvc5.Owin" Version="7.0.0" />
+    <PackageReference Include="Autofac.Owin" Version="8.0.0" />
+    <PackageReference Include="Autofac.SignalR2" Version="7.0.0" />
+    <PackageReference Include="Autofac.Wcf" Version="8.0.0" />
+    <PackageReference Include="Autofac.Web" Version="8.0.0" />
+    <PackageReference Include="Autofac.WebApi2" Version="7.0.0" />
+    <PackageReference Include="Autofac.WebApi2.Owin" Version="7.0.0" />
 
     <!-- References to force version alignment -->
     <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.3.0" />
@@ -35,31 +34,37 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <!-- Modern .NET integrations and core libraries -->
-    <PackageReference Include="Autofac.AspNetCore.Multitenant" Version="8.0.0" />
-    <PackageReference Include="Autofac.Configuration" Version="7.0.0" />
-    <PackageReference Include="Autofac.Diagnostics.DotGraph" Version="2.0.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="11.0.0" />
-    <PackageReference Include="Autofac.Extras.AggregateService" Version="6.1.2" />
-    <PackageReference Include="Autofac.Extras.AttributeMetadata" Version="6.0.0" />
-    <PackageReference Include="Autofac.Extras.CommonServiceLocator" Version="6.1.0" />
-    <PackageReference Include="Autofac.Extras.DynamicProxy" Version="7.1.0" />
-    <PackageReference Include="Autofac.Extras.FakeItEasy" Version="7.0.0" />
-    <PackageReference Include="Autofac.Extras.Moq" Version="7.0.0" />
-    <PackageReference Include="Autofac.Multitenant" Version="8.1.0" />
-    <PackageReference Include="Autofac.Pooling" Version="1.0.1" />
+    <PackageReference Include="Autofac.AspNetCore.Multitenant" Version="9.0.0" />
+    <PackageReference Include="Autofac.Configuration" Version="8.0.1" />
+    <PackageReference Include="Autofac.Diagnostics.DotGraph" Version="3.0.1" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="11.0.2" />
+    <PackageReference Include="Autofac.Extras.AggregateService" Version="7.0.1" />
+    <PackageReference Include="Autofac.Extras.AttributeMetadata" Version="7.0.0" />
+    <PackageReference Include="Autofac.Extras.CommonServiceLocator" Version="7.0.1" />
+    <PackageReference Include="Autofac.Extras.DynamicProxy" Version="8.1.0" />
+    <PackageReference Include="Autofac.Extras.FakeItEasy" Version="8.0.1" />
+    <PackageReference Include="Autofac.Extras.Moq" Version="8.0.1" />
+    <PackageReference Include="Autofac.Mef" Version="8.0.1" />
+    <PackageReference Include="Autofac.Multitenant" Version="9.0.1" />
+    <PackageReference Include="Autofac.Pooling" Version="2.0.1" />
+    <PackageReference Include="Autofac.ServiceFabric" Version="5.0.0" />
   </ItemGroup>
 
+  <!--
+    NuGet leaves package XML docs out of the output, but DocFX needs them next to
+    the assemblies to pick up doc comments. The Exists() check has to batch per
+    item on the Copy task; on the ItemGroup it evaluates against the whole
+    flattened list, never matches, and silently yields a reference with no docs.
+  -->
   <Target Name="CopyReferenceXmlDocs" AfterTargets="Build">
     <ItemGroup>
-      <ReferenceXmlDocs
-        Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).xml')"
-        Condition="Exists(@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).xml'))" />
+      <ReferenceXmlDocs Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).xml')" />
     </ItemGroup>
 
     <Copy
       SourceFiles="@(ReferenceXmlDocs)"
       DestinationFolder="$(OutputPath)"
       SkipUnchangedFiles="true"
-      Condition="'@(ReferenceXmlDocs)' != ''" />
+      Condition="Exists('%(ReferenceXmlDocs.FullPath)')" />
   </Target>
 </Project>

--- a/build-apidoc/docfx.json
+++ b/build-apidoc/docfx.json
@@ -71,20 +71,18 @@
       "src": [
         {
           "files": [
-            "Placeholder/bin/Debug/net472/Autofac.Integration.Mvc*.dll",
-            "Placeholder/bin/Debug/net472/Autofac.Integration.Mvc*.xml",
-            "Placeholder/bin/Debug/net472/Autofac.Integration.Owin.dll",
-            "Placeholder/bin/Debug/net472/Autofac.Integration.Owin.xml",
-            "Placeholder/bin/Debug/net472/Autofac.Integration.ServiceFabric.dll",
-            "Placeholder/bin/Debug/net472/Autofac.Integration.ServiceFabric.xml",
-            "Placeholder/bin/Debug/net472/Autofac.Integration.SignalR.dll",
-            "Placeholder/bin/Debug/net472/Autofac.Integration.SignalR.xml",
-            "Placeholder/bin/Debug/net472/Autofac.Integration.Wcf.dll",
-            "Placeholder/bin/Debug/net472/Autofac.Integration.Wcf.xml",
-            "Placeholder/bin/Debug/net472/Autofac.Integration.Web*.dll",
-            "Placeholder/bin/Debug/net472/Autofac.Integration.Web*.xml",
-            "Placeholder/bin/Debug/net472/Autofac.Multitenant.Wcf.dll",
-            "Placeholder/bin/Debug/net472/Autofac.Multitenant.Wcf.xml"
+            "Placeholder/bin/Debug/net481/Autofac.Integration.Mvc*.dll",
+            "Placeholder/bin/Debug/net481/Autofac.Integration.Mvc*.xml",
+            "Placeholder/bin/Debug/net481/Autofac.Integration.Owin.dll",
+            "Placeholder/bin/Debug/net481/Autofac.Integration.Owin.xml",
+            "Placeholder/bin/Debug/net481/Autofac.Integration.SignalR.dll",
+            "Placeholder/bin/Debug/net481/Autofac.Integration.SignalR.xml",
+            "Placeholder/bin/Debug/net481/Autofac.Integration.Wcf.dll",
+            "Placeholder/bin/Debug/net481/Autofac.Integration.Wcf.xml",
+            "Placeholder/bin/Debug/net481/Autofac.Integration.Web*.dll",
+            "Placeholder/bin/Debug/net481/Autofac.Integration.Web*.xml",
+            "Placeholder/bin/Debug/net481/Autofac.Multitenant.Wcf.dll",
+            "Placeholder/bin/Debug/net481/Autofac.Multitenant.Wcf.xml"
           ]
         }
       ]


### PR DESCRIPTION
## Why

The generated API reference at <https://autofac.org/apidoc/> has no documentation text on any member — only signatures. All 262 committed `build-apidoc/api/*.yml` files contain zero `summary:` fields.

The cause is in `Placeholder.csproj`, where the `Exists()` condition sat on the `ReferenceXmlDocs` *item*:

```xml
<ReferenceXmlDocs
  Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).xml')"
  Condition="Exists(@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).xml'))" />
```

MSBuild evaluates that `Exists()` against the whole semicolon-joined list rather than per item, so it is never true, the item group comes out empty, and no package XML docs reach the output. DocFX then reads bare assemblies. The condition reads as though it belongs there, which is presumably why it survived, so the fix carries a comment explaining why it can't.

The project also still targeted `net472`, which no longer matches any shipped package, and every Autofac reference was at least one release behind.

## What changed

**The XML doc copy.** The condition moves to the `Copy` task, where it batches per item.

**`net472` → `net481`** in `Placeholder.csproj`, `Documentation.proj`, and the `docfx.json` legacy globs. Every one of those packages dropped `net472` in its latest major.

**Package references to current** — core to 9.3.2, all integrations to their latest release, docfx 2.77.0 → 2.78.5.

**`Autofac.Mef` is now explicit.** It was previously documented only because `Autofac.Extras.AttributeMetadata` happens to depend on it and the `Autofac*.dll` glob picked it up.

**`Autofac.ServiceFabric` moves from the legacy set to current.** 5.0.0 targets only `netstandard2.0`/`netstandard2.1` and dropped its x64 platform target, so it is no longer a Windows-desktop-only assembly.

## Verification

`dotnet msbuild build-apidoc/Documentation.proj` succeeds on macOS for both TFMs.

To establish the baseline rather than infer it, I stashed the change and re-ran:

| | before | after |
|---|---|---|
| files with `summary:` | 0 of 262 | 283 of 342 |
| `InvalidAssemblyReference` warnings | 3982 | 3853 |

Traced one member through the whole chain — assembly → XML → DocFX metadata → HTML. `api/Autofac.ContainerBuilder.html` now renders "Used to build an IContainer from component registrations."

Also confirmed the version bump took effect (`Autofac.ServiceKeyAttribute.yml` and `Autofac.ParameterExtensions.yml` are present, both new in 9.1.0), that the obsolete AttributeMetadata filter types removed in 7.0.0 are gone, and that `Autofac.Integration.ServiceFabric` appears in `api/` and not in `api/legacy/`.

`pre-commit run` clean on the changed files.

### Not addressed

The ~3850 `InvalidAssemblyReference` warnings for BCL assemblies are pre-existing — 3982 before this change — and come from DocFX resolving `System.*, Version=10.0.0.0` without the shared framework present. They are noise rather than failures; quieting them is a separate change.
