### PR TITLE
Repair broken links and move off retired documentation hosts

### DIFF
--- a/docs/advanced/adapters-decorators.rst
+++ b/docs/advanced/adapters-decorators.rst
@@ -5,9 +5,9 @@ Adapters and Decorators
 Adapters
 ========
 
-The `adapter pattern <http://en.wikipedia.org/wiki/Adapter_pattern>`_ takes one service contract and adapts it (like a wrapper) to another.
+The `adapter pattern <https://en.wikipedia.org/wiki/Adapter_pattern>`_ takes one service contract and adapts it (like a wrapper) to another.
 
-This `introductory article <http://nblumhardt.com/2010/04/lightweight-adaptation-coming-soon/>`_ describes a concrete example of the adapter pattern and how you can work with it in Autofac.
+This `introductory article <https://nblumhardt.com/2010/04/lightweight-adaptation-coming-soon/>`_ describes a concrete example of the adapter pattern and how you can work with it in Autofac.
 
 Autofac provides built-in adapter registration so you can register a set of services and have them each automatically adapted to a different interface.
 
@@ -39,7 +39,7 @@ Autofac provides built-in adapter registration so you can register a set of serv
 Decorators
 ==========
 
-The `decorator pattern <http://en.wikipedia.org/wiki/Decorator_pattern>`_ is somewhat similar to the adapter pattern, where one service "wraps" another. However, in contrast to adapters, decorators expose the *same service* as what they're decorating. The point of using decorators is to add functionality to an object without changing the object's signature.
+The `decorator pattern <https://en.wikipedia.org/wiki/Decorator_pattern>`_ is somewhat similar to the adapter pattern, where one service "wraps" another. However, in contrast to adapters, decorators expose the *same service* as what they're decorating. The point of using decorators is to add functionality to an object without changing the object's signature.
 
 Autofac provides built-in decorator registration so you can register services and have them automatically wrapped with decorator classes.
 
@@ -160,7 +160,7 @@ Classic Syntax
 
 The "classic syntax" has been around since Autofac 2.4 and still works today. It's more complicated than the newer syntax but if you have some existing code that uses it, that code will continue to work.
 
-This `article <http://nblumhardt.com/2011/01/decorator-support-in-autofac-2-4/>`_ has some details about how decorators work in Autofac.
+This `article <https://nblumhardt.com/2011/01/decorator-support-in-autofac-2-4/>`_ has some details about how decorators work in Autofac.
 
 .. sourcecode:: csharp
 

--- a/docs/advanced/aggregate-services.rst
+++ b/docs/advanced/aggregate-services.rst
@@ -9,7 +9,7 @@ An aggregate service is useful when you need to treat a set of dependencies as o
 
 An example is super- and subclasses where the superclass have one or more constructor-injected dependencies. The subclasses must usually inherit these dependencies, even though they might only be useful to the superclass. With an aggregate service, the superclass constructor parameters can be collapsed into one parameter, reducing the repetitiveness in subclasses. Another important side effect is that subclasses are now insulated against changes in the superclass dependencies, introducing a new dependency in the superclass means only changing the aggregate service definition.
 
-The pattern and this example `are both further elaborated here <http://peterspattern.com/dependency-injection-and-class-inheritance>`_.
+The pattern and this example `are both further elaborated here <https://peterspattern.com/dependency-injection-and-class-inheritance>`_.
 
 Aggregate services can be implemented by hand, e.g. by building a class with constructor-injected dependencies and exposing those as properties. Writing and maintaining aggregate service classes and accompanying tests can quickly get tedious though. The AggregateService extension to Autofac lets you generate aggregate services directly from interface definitions without having to write any implementation.
 
@@ -157,7 +157,7 @@ Because the implementation is ordinary, statically-compiled C#, this path involv
 Dynamic Proxy (Fallback)
 --------------------------
 
-When the generator can't statically determine the aggregate service interface, the implementation is generated at runtime instead, using DynamicProxy from `the Castle Project <http://castleproject.org>`_. Given the interface, a proxy is generated implementing it, translating calls to properties and methods into ``Resolve`` calls on an Autofac context.
+When the generator can't statically determine the aggregate service interface, the implementation is generated at runtime instead, using DynamicProxy from `the Castle Project <https://castleproject.org>`_. Given the interface, a proxy is generated implementing it, translating calls to properties and methods into ``Resolve`` calls on an Autofac context.
 
 The fallback is used when the interface isn't visible to the generator at compile time, for example:
 
@@ -184,7 +184,7 @@ Performance Considerations
 
 When the source generator produces the implementation, method and property access is a direct, statically-compiled ``Resolve`` call with no proxy indirection - the fastest path and the recommended default.
 
-When the dynamic proxy fallback is used, method calls pass through a dynamic proxy, so there is a small but non-zero amount of overhead on each method call. A performance study on Castle DynamicProxy vs other frameworks can be found `here <http://kozmic.pl/2009/03/31/dynamic-proxy-frameworks-comparison-update/>`_.
+When the dynamic proxy fallback is used, method calls pass through a dynamic proxy, so there is a small but non-zero amount of overhead on each method call. A performance study on Castle DynamicProxy vs other frameworks can be found `here <https://kozmic.pl/2009/03/31/dynamic-proxy-frameworks-comparison-update/>`_.
 
 .. _aggregate_services_aot:
 

--- a/docs/advanced/interceptors.rst
+++ b/docs/advanced/interceptors.rst
@@ -2,7 +2,7 @@
 Type Interceptors
 =================
 
-`Castle.Core <https://github.com/castleproject/Core>`_, part of `the Castle Project <http://castleproject.org>`_, provides a method interception framework called "DynamicProxy."
+`Castle.Core <https://github.com/castleproject/Core>`_, part of `the Castle Project <https://castleproject.org>`_, provides a method interception framework called "DynamicProxy."
 
 The ``Autofac.Extras.DynamicProxy`` integration package enables method calls on Autofac components to be intercepted by other components. Common use-cases are transaction handling, logging, and declarative security. You can use ``Autofac.Extras.DynamicProxy2`` for Autofac versions up to 4.0.0
 

--- a/docs/advanced/metadata.rst
+++ b/docs/advanced/metadata.rst
@@ -181,7 +181,7 @@ To get attributed metadata working in your solution, you need to perform the fol
 Create Your Metadata Attribute
 ------------------------------
 
-A metadata attribute is a ``System.Attribute`` implementation that has the `System.ComponentModel.Composition.MetadataAttributeAttribute <https://msdn.microsoft.com/en-us/library/system.componentmodel.composition.metadataattributeattribute.aspx>`_ applied.
+A metadata attribute is a ``System.Attribute`` implementation that has the `System.ComponentModel.Composition.MetadataAttributeAttribute <https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.composition.metadataattributeattribute>`_ applied.
 
 Any publicly-readable properties on the attribute will become name/value attribute pairs - the name of the metadata will be the property name and the value will be the property value.
 

--- a/docs/advanced/multitenant.rst
+++ b/docs/advanced/multitenant.rst
@@ -385,7 +385,7 @@ Whether or not you choose to use the provided ``Autofac.Multitenant.Wcf.TenantPr
 
 ``Autofac.Multitenant.Wcf`` provides the ``Autofac.Multitenant.Wcf.TenantIdentificationContextExtension`` as an extension to the WCF ``OperationContext`` for just this purpose.
 
-Early in the operation lifecycle (generally in a `System.ServiceModel.Dispatcher.IDispatchMessageInspector.AfterReceiveRequest() <https://msdn.microsoft.com/en-us/library/system.servicemodel.dispatcher.idispatchmessageinspector.afterreceiverequest.aspx>`_ implementation), you can add the ``TenantIdentificationContextExtension`` to the current ``OperationContext`` so the tenant can be easily identified. A sample ``AfterReceiveRequest()`` implementation below shows this in action:
+Early in the operation lifecycle (generally in a `System.ServiceModel.Dispatcher.IDispatchMessageInspector.AfterReceiveRequest() <https://learn.microsoft.com/en-us/dotnet/api/system.servicemodel.dispatcher.idispatchmessageinspector.afterreceiverequest>`_ implementation), you can add the ``TenantIdentificationContextExtension`` to the current ``OperationContext`` so the tenant can be easily identified. A sample ``AfterReceiveRequest()`` implementation below shows this in action:
 
 .. sourcecode:: csharp
 

--- a/docs/advanced/multitenant.rst
+++ b/docs/advanced/multitenant.rst
@@ -651,6 +651,6 @@ Tenant ID Strategy Tips
 Example
 =======
 
-The Autofac example repository has a `multitenant WCF service <https://github.com/autofac/Examples/tree/master/src/MultitenantExample.WcfService>`_ and `associated client MVC application <https://github.com/autofac/Examples/tree/master/src/MultitenantExample.MvcApplication>`_ to illustrate how :doc:`multitenant service hosting <../advanced/multitenant>` works.
+The Autofac example repository has a `multitenant WCF service <https://github.com/autofac/Examples/tree/main/src/MultitenantExample.WcfService>`_ and `associated client MVC application <https://github.com/autofac/Examples/tree/main/src/MultitenantExample.MvcApplication>`_ to illustrate how :doc:`multitenant service hosting <../advanced/multitenant>` works.
 
-There is also a `very simple console application <https://github.com/autofac/Examples/tree/master/src/MultitenantExample.ConsoleApplication>`_ example.
+There is also a `very simple console application <https://github.com/autofac/Examples/tree/main/src/MultitenantExample.ConsoleApplication>`_ example.

--- a/docs/advanced/pooled-instances.rst
+++ b/docs/advanced/pooled-instances.rst
@@ -126,7 +126,7 @@ If you, in fact, do want your pool to have custom behavior like blocking until a
 
 .. note::
 
-    The Autofac Pooling behavior is built on top of the `Object Pool <https://docs.microsoft.com/en-us/aspnet/core/performance/objectpool>`_ implementation
+    The Autofac Pooling behavior is built on top of the `Object Pool <https://learn.microsoft.com/en-us/aspnet/core/performance/objectpool>`_ implementation
     available from `the Microsoft.Extensions.ObjectPool package <https://www.nuget.org/packages/Microsoft.Extensions.ObjectPool/>`_.
 
     The behavior of that pool informs a lot of the behavior of Autofac.Pooling.

--- a/docs/advanced/registration-sources.rst
+++ b/docs/advanced/registration-sources.rst
@@ -22,7 +22,7 @@ You can use the ``Autofac.Features.ResolveAnything.AnyConcreteTypeNotAlreadyRegi
 
 Contravariant Registration Source
 =================================
-The ``ContravariantRegistrationSource`` is helpful in registering types that need to be later resolved in a `contravariant context <https://docs.microsoft.com/en-us/dotnet/standard/generics/covariance-and-contravariance>`_ (using a more generic / less derived type than originally specified).
+The ``ContravariantRegistrationSource`` is helpful in registering types that need to be later resolved in a `contravariant context <https://learn.microsoft.com/en-us/dotnet/standard/generics/covariance-and-contravariance>`_ (using a more generic / less derived type than originally specified).
 
 **If you use this source, register it before registering other things.** Just as with standard registrations, registration sources are evaluated in the order of registration. If you register an open generic (which is *also* a registration source under the covers) and *then* register ``ContravariantRegistrationSource``, you will not get the outcome you expect.
 

--- a/docs/advanced/registration-sources.rst
+++ b/docs/advanced/registration-sources.rst
@@ -4,7 +4,7 @@ Registration Sources
 
 A *registration source* is a way to dynamically feed registrations into an Autofac component context (e.g., container or lifetime scope).
 
-Registration sources are created by implementing the ``IRegistrationSource`` interface. Many of the Autofac features are implemented this way - for example, the :doc:`implicit relationship types <../resolve/relationships>` are added via registration sources. (You didn't think we actually registered every single type of collection manually into the container, did you?) `Nick Blumhardt has a great blog article about how this works. <http://nblumhardt.com/2010/01/declarative-context-adapters-autofac2/>`_
+Registration sources are created by implementing the ``IRegistrationSource`` interface. Many of the Autofac features are implemented this way - for example, the :doc:`implicit relationship types <../resolve/relationships>` are added via registration sources. (You didn't think we actually registered every single type of collection manually into the container, did you?) `Nick Blumhardt has a great blog article about how this works. <https://nblumhardt.com/2010/01/declarative-context-adapters-autofac2/>`_
 
 Registration sources are great when you don't have a finite set of registrations you can add to a container. Many times, :doc:`assembly scanning <../register/scanning>` and/or :doc:`use of modules <../configuration/modules>` can address dynamic registration concerns... but when all else fails or those means don't accomplish what you're looking to do, a registration source may be the way to go.
 

--- a/docs/best-practices/index.rst
+++ b/docs/best-practices/index.rst
@@ -36,12 +36,12 @@ Autofac infers implementation type from the expressions you use to register comp
 Use Constructor Injection
 =========================
 
-The concept of using constructor injection for required dependencies and property injection for optional dependencies is quite well known. An alternative, however, is to use the `"Null Object" <http://en.wikipedia.org/wiki/Null_Object_pattern>`_ or `"Special Case" <http://martinfowler.com/eaaCatalog/specialCase.html>`_ pattern to provide default, do-nothing implementations for the optional service. This prevents the possibility of special-case code in the implementation of the component (e.g. ``if (Logger != null) Logger.Log("message");``).
+The concept of using constructor injection for required dependencies and property injection for optional dependencies is quite well known. An alternative, however, is to use the `"Null Object" <https://en.wikipedia.org/wiki/Null_Object_pattern>`_ or `"Special Case" <https://martinfowler.com/eaaCatalog/specialCase.html>`_ pattern to provide default, do-nothing implementations for the optional service. This prevents the possibility of special-case code in the implementation of the component (e.g. ``if (Logger != null) Logger.Log("message");``).
 
 Use Relationship Types, Not Service Locators
 ============================================
 
-Giving components access to the container, storing it in a public static property, or making functions like ``Resolve()`` available on a global "IoC" class defeats the purpose of using dependency injection. Such designs have more in common with the `Service Locator <http://martinfowler.com/articles/injection.html#UsingAServiceLocator>`_ pattern.
+Giving components access to the container, storing it in a public static property, or making functions like ``Resolve()`` available on a global "IoC" class defeats the purpose of using dependency injection. Such designs have more in common with the `Service Locator <https://martinfowler.com/articles/injection.html#UsingAServiceLocator>`_ pattern.
 
 If components have a dependency on the container (or on a lifetime scope), look at how they're using the container to retrieve services, and add those services to the component's (dependency injected) constructor arguments instead.
 
@@ -55,7 +55,7 @@ Autofac overrides component registrations by default. This means that an applica
 Use Profilers for Performance Checking
 ======================================
 
-Before doing any performance optimization or making assumptions about potential memory leaks, **always run a profiler** like `SlimTune <http://code.google.com/p/slimtune/>`_, `dotTrace <http://www.jetbrains.com/profiler/>`_, or `ANTS <http://www.red-gate.com/products/dotnet-development/ants-performance-profiler/>`_ to see where time is truly being spent. It might not be where you think.
+Before doing any performance optimization or making assumptions about potential memory leaks, **always run a profiler** like `SlimTune <http://code.google.com/p/slimtune/>`_, `dotTrace <https://www.jetbrains.com/profiler/>`_, or `ANTS <https://www.red-gate.com/products/dotnet-development/ants-performance-profiler/>`_ to see where time is truly being spent. It might not be where you think.
 
 Register Once, Resolve Many
 ===========================

--- a/docs/configuration/xml.rst
+++ b/docs/configuration/xml.rst
@@ -202,7 +202,7 @@ You are allowed to register *the same module multiple times using different para
 
 Type Names
 ----------
-In all cases where you see a type name (component type, service types, module type) it is expected to be `the standard, assembly qualified type name <https://msdn.microsoft.com/en-us/library/yfsftwz6(v=vs.110).aspx>`_ that you would normally be able to pass to ``Type.GetType(string typename)``. If the type is in the ``defaultAssembly`` you can leave the assembly name off, but it doesn't hurt to put it there regardless.
+In all cases where you see a type name (component type, service types, module type) it is expected to be `the standard, assembly qualified type name <https://learn.microsoft.com/en-us/dotnet/framework/reflection-and-codedom/specifying-fully-qualified-type-names>`_ that you would normally be able to pass to ``Type.GetType(string typename)``. If the type is in the ``defaultAssembly`` you can leave the assembly name off, but it doesn't hurt to put it there regardless.
 
 Assembly qualified type names have the full type with namespace, a comma, and the name of the assembly, like ``Autofac.Example.Calculator.OperationModule, Autofac.Example.Calculator``. In that case, ``Autofac.Example.Calculator.OperationModule`` is the type and it's in the ``Autofac.Example.Calculator`` assembly.
 

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -2,6 +2,6 @@
 Contributor Guide
 =================
 
-`The Autofac contributor's guide is located in GitHub. <https://github.com/autofac/.github/blob/master/CONTRIBUTING.md>`_ If you are interested in contributing or building the project from source, check it out.
+`The Autofac contributor's guide is located in GitHub. <https://github.com/autofac/.github/blob/main/CONTRIBUTING.md>`_ If you are interested in contributing or building the project from source, check it out.
 
-Contributors must follow the `Code of Conduct <https://github.com/autofac/.github/blob/master/CODE_OF_CONDUCT.md>`_.
+Contributors must follow the `Code of Conduct <https://github.com/autofac/.github/blob/main/CODE_OF_CONDUCT.md>`_.

--- a/docs/faq/binding-redirect.rst
+++ b/docs/faq/binding-redirect.rst
@@ -12,7 +12,7 @@ We do this because, generally speaking, we don't want to force anyone to update 
 
 **In .NET Core this "just works."** The project system figures out the latest version of Autofac in the project (i.e., your direct reference) and redirects all bindings to that. No extra cruft, no work. Like magic.
 
-**In .NET full framework projects this results in is the need to use assembly binding redirects.** `This is the official supported way <https://msdn.microsoft.com/en-us/library/vstudio/2fc472t2.aspx>`_ to tell the .NET runtime that you need to redirect requests for one version of a strong-named assembly to a later version of that assembly. This is common enough that both NuGet and Visual Studio will, in many cases, automatically add these to your configuration files.
+**In .NET full framework projects this results in is the need to use assembly binding redirects.** `This is the official supported way <https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/redirect-assembly-versions>`_ to tell the .NET runtime that you need to redirect requests for one version of a strong-named assembly to a later version of that assembly. This is common enough that both NuGet and Visual Studio will, in many cases, automatically add these to your configuration files.
 
 Here's an example of what assembly binding redirects look like:
 
@@ -53,7 +53,7 @@ Here's an example of what assembly binding redirects look like:
         </runtime>
     </configuration>
 
-Assembly binding redirects are an unfortunate side-effect of `assembly strong-naming <https://msdn.microsoft.com/en-us/library/wd40t7ad.aspx>`_. You don't need binding redirects if assemblies aren't strong-named; but there are some environments that require assemblies to be strong-named, so Autofac continues to strong-name assemblies.
+Assembly binding redirects are an unfortunate side-effect of `assembly strong-naming <https://learn.microsoft.com/en-us/dotnet/standard/assembly/strong-named>`_. You don't need binding redirects if assemblies aren't strong-named; but there are some environments that require assemblies to be strong-named, so Autofac continues to strong-name assemblies.
 
 **Even if Autofac always kept every reference up to date, you would still not escape assembly binding redirects.** Autofac integration packages, like :doc:`the Web API integration <../integration/webapi>`, rely on other strong-named packages that then have their own dependencies. For example, the `Microsoft Web API packages <https://www.nuget.org/packages/Microsoft.AspNet.WebApi.Client/>`_ rely on `Newtonsoft.Json <https://www.nuget.org/packages/Newtonsoft.Json/>`_ and they don't always keep up with the latest version. They instead specify a minimum compatible version. *If you update your local version of Newtonsoft.Json... you get a binding redirect.*
 

--- a/docs/faq/iis-restart.rst
+++ b/docs/faq/iis-restart.rst
@@ -6,7 +6,7 @@ Sometimes you want to use the :doc:`assembly scanning <../register/scanning>` me
 
 When hosting applications in IIS all assemblies are loaded into the ``AppDomain`` when the application first starts, but **when the AppDomain is recycled by IIS the assemblies are then only loaded on demand.**
 
-To avoid this issue use the `GetReferencedAssemblies() <https://msdn.microsoft.com/en-us/library/system.web.compilation.buildmanager.getreferencedassemblies.aspx>`_ method on `System.Web.Compilation.BuildManager <https://msdn.microsoft.com/en-us/library/system.web.compilation.buildmanager.aspx>`_ to get a list of the referenced assemblies instead:
+To avoid this issue use the `GetReferencedAssemblies() <https://learn.microsoft.com/en-us/dotnet/api/system.web.compilation.buildmanager.getreferencedassemblies>`_ method on `System.Web.Compilation.BuildManager <https://learn.microsoft.com/en-us/dotnet/api/system.web.compilation.buildmanager>`_ to get a list of the referenced assemblies instead:
 
 .. sourcecode:: csharp
 

--- a/docs/faq/instance-per-session.rst
+++ b/docs/faq/instance-per-session.rst
@@ -36,7 +36,7 @@ Session isn't always rehydrated. If the handler being accessed (e.g., the web fo
 Unreliable Disposal
 -------------------
 
-``Session_End`` doesn't always fire. `Per the docs on SessionStateModule.End <https://msdn.microsoft.com/en-us/library/system.web.sessionstate.sessionstatemodule.end.aspx>`_, if you use out-of-proc session state you won't actually get the ``Session_End`` event, so you won't be able to clean up.
+``Session_End`` doesn't always fire. `Per the docs on SessionStateModule.End <https://learn.microsoft.com/en-us/dotnet/api/system.web.sessionstate.sessionstatemodule.end>`_, if you use out-of-proc session state you won't actually get the ``Session_End`` event, so you won't be able to clean up.
 
 How to Do It
 ============

--- a/docs/faq/isolate-autofac.rst
+++ b/docs/faq/isolate-autofac.rst
@@ -12,7 +12,7 @@ It can be desirable to try to keep references to the Autofac assemblies and IoC 
 Application Startup
 ===================
 
-Application startup is where your IoC container is built up and registrations are made. This is also where the IoC container is hooked into the `composition root <http://blog.ploeh.dk/2011/07/28/CompositionRoot/>`_ for the application. For console apps, this is the ``Main`` method; for ASP.NET apps this is the ``Startup`` class or the ``Global.asax``; for other applications there are other entry points.
+Application startup is where your IoC container is built up and registrations are made. This is also where the IoC container is hooked into the `composition root <https://blog.ploeh.dk/2011/07/28/CompositionRoot/>`_ for the application. For console apps, this is the ``Main`` method; for ASP.NET apps this is the ``Startup`` class or the ``Global.asax``; for other applications there are other entry points.
 
 You shouldn't try to separate the IoC container from this section of your application. This is the point where it specifically hooks into things. If you're trying to get Autofac away from your ``Global.asax`` or out of your ``Startup`` class (that is, you're trying to remove the Autofac package/assembly reference from the assembly with this code in it), **save yourself some time and don't do that**. You will potentially sink a lot of time into writing abstractions and wrappers around things only to replicate a lot of Autofac-specific syntax and capabilities.
 
@@ -68,7 +68,7 @@ However, there are a few areas where you may find yourself tied to Autofac...
 
 Service Location
 ----------------
-Some frameworks are lacking composition root hooks to enable all dependency injection hooks at the app startup level. One example of this is classic ASP.NET ``HttpModules`` - there is generally no hook that allows you to inject dependencies into a module. In cases like this, you may find use of service location useful (though you should definitely minimize service location where possible `given it's an anti-pattern <http://blog.ploeh.dk/2010/02/03/ServiceLocatorisanAnti-Pattern/>`_).
+Some frameworks are lacking composition root hooks to enable all dependency injection hooks at the app startup level. One example of this is classic ASP.NET ``HttpModules`` - there is generally no hook that allows you to inject dependencies into a module. In cases like this, you may find use of service location useful (though you should definitely minimize service location where possible `given it's an anti-pattern <https://blog.ploeh.dk/2010/02/03/ServiceLocatorisanAnti-Pattern/>`_).
 
 In cases where you need a service locator but don't want to tie to Autofac, consider using an abstraction like `CommonServiceLocator <https://www.nuget.org/packages/CommonServiceLocator/>`_ or `Microsoft.Extensions.DependencyInjection <https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/>`_. In ASP.NET MVC applications, you're already provided with a ``DependencyResolver`` for service location; other application types may have similar abstractions already provided. By using one of these abstractions, you can remove the Autofac reference... though you'll have to keep a reference to the abstraction.
 

--- a/docs/faq/select-by-context.rst
+++ b/docs/faq/select-by-context.rst
@@ -65,7 +65,7 @@ Option 1: Redesign Your Interfaces
 
 When you run into a situation where you have a bunch of components that implement identical services but *they can't be treated identically*, **this is generally an interface design problem**.
 
-From an object oriented development perspective, you'd want your objects to adhere to the `Liskov substitution principle <http://en.wikipedia.org/wiki/Liskov_substitution_principle>`_ and this sort of breaks that.
+From an object oriented development perspective, you'd want your objects to adhere to the `Liskov substitution principle <https://en.wikipedia.org/wiki/Liskov_substitution_principle>`_ and this sort of breaks that.
 
 Think about it from another angle: the standard "animal" example in object orientation. Say you have some animal objects and you are creating a special class that represents a bird cage that can hold small birds:
 

--- a/docs/faq/xamarin-issues.rst
+++ b/docs/faq/xamarin-issues.rst
@@ -2,9 +2,9 @@
 Why are things in my Xamarin app misbehaving?
 =============================================
 
-**Autofac targets .NET Framework and .NET Standard.** `This makes the code fairly portable across platforms. <https://docs.microsoft.com/en-us/dotnet/standard/net-standard>`__ It can be used in, among other things, Mono, Xamarin, and Universal Windows Platform apps.
+**Autofac targets .NET Framework and .NET Standard.** `This makes the code fairly portable across platforms. <https://learn.microsoft.com/en-us/dotnet/standard/net-standard>`__ It can be used in, among other things, Mono, Xamarin, and Universal Windows Platform apps.
 
-`Xamarin provides a cross-platform compiler <https://docs.microsoft.com/en-us/xamarin/cross-platform/get-started/introduction-to-mobile-development>`__ that can take C# and .NET code and compile that into native applications. From `the docs <https://docs.microsoft.com/en-us/xamarin/cross-platform/get-started/introduction-to-mobile-development>`__:
+`Xamarin provides a cross-platform compiler <https://learn.microsoft.com/en-us/xamarin/cross-platform/get-started/introduction-to-mobile-development>`__ that can take C# and .NET code and compile that into native applications. From `the docs <https://learn.microsoft.com/en-us/xamarin/cross-platform/get-started/introduction-to-mobile-development>`__:
 
   On iOS, Xamarin’s Ahead-of-Time (AOT) Compiler compiles Xamarin.iOS applications directly to native ARM assembly code. On Android, Xamarin’s compiler compiles down to Intermediate Language (IL), which is then Just-in-Time (JIT) compiled to native assembly when the application launches.
 

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -22,7 +22,7 @@ This getting started guide walks you through these steps for a simple console ap
 Structuring the Application
 ===========================
 
-The idea behind inversion of control is that, rather than tie the classes in your application together and let classes "new up" their dependencies, you switch it around so dependencies are instead passed in during class construction. `Martin Fowler has an excellent article explaining dependency injection/inversion of control <http://martinfowler.com/articles/injection.html>`_ if you want more on that.
+The idea behind inversion of control is that, rather than tie the classes in your application together and let classes "new up" their dependencies, you switch it around so dependencies are instead passed in during class construction. `Martin Fowler has an excellent article explaining dependency injection/inversion of control <https://martinfowler.com/articles/injection.html>`_ if you want more on that.
 
 For our sample app, we'll define a class that writes the current date out. However, we don't want it tied to the ``Console`` because we want to be able to test the class later or use it in a place where the console isn't available.
 
@@ -225,7 +225,7 @@ Now when you run your program...
 
 Later, if you want your application to write a different date, you could implement a different ``IDateWriter`` and then change the registration at app startup. You don't have to change any other classes. Yay, inversion of control!
 
-**Note: generally speaking, service location is largely considered an anti-pattern** `(see article) <http://blog.ploeh.dk/2010/02/03/ServiceLocatorIsAnAntiPattern.aspx>`_. That is, manually creating scopes everywhere and sprinkling use of the container through your code is not necessarily the best way to go. Using the :doc:`Autofac integration libraries <../integration/index>` you usually won't have to do what we did in the sample app above. Instead, things get resolved from a central, "top level" location in the application and manual resolution is rare. Of course, how you design your app is up to you.
+**Note: generally speaking, service location is largely considered an anti-pattern** `(see article) <https://blog.ploeh.dk/2010/02/03/ServiceLocatorIsAnAntiPattern.aspx>`_. That is, manually creating scopes everywhere and sprinkling use of the container through your code is not necessarily the best way to go. Using the :doc:`Autofac integration libraries <../integration/index>` you usually won't have to do what we did in the sample app above. Instead, things get resolved from a central, "top level" location in the application and manual resolution is rare. Of course, how you design your app is up to you.
 
 Going Further
 =============
@@ -241,7 +241,7 @@ Need Help?
 
 - You can `ask questions on StackOverflow <https://stackoverflow.com/questions/tagged/autofac>`_.
 - You can `participate in the Autofac Google Group <https://groups.google.com/forum/#forum/autofac>`_.
-- There's an introductory `Autofac tutorial <http://www.codeproject.com/KB/architecture/di-with-autofac.aspx>`_ on CodeProject.
+- There's an introductory `Autofac tutorial <https://www.codeproject.com/KB/architecture/di-with-autofac.aspx>`_ on CodeProject.
 - We have :doc:`advanced debugging tips <../troubleshooting/index>` if you want to dive deep.
 
 Building from Source

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Welcome to Autofac's Documentation!
 
 .. image:: logo.png
 
-Autofac is an addictive `IoC container <http://martinfowler.com/articles/injection.html>`_ for .NET. It manages the dependencies between classes so that **applications stay easy to change as they grow** in size and complexity. This is achieved by treating regular .NET classes as :doc:`components <glossary>`.
+Autofac is an addictive `IoC container <https://martinfowler.com/articles/injection.html>`_ for .NET. It manages the dependencies between classes so that **applications stay easy to change as they grow** in size and complexity. This is achieved by treating regular .NET classes as :doc:`components <glossary>`.
 
 .. toctree::
    :maxdepth: 3

--- a/docs/integration/aspnetcore.rst
+++ b/docs/integration/aspnetcore.rst
@@ -2,7 +2,7 @@
 ASP.NET Core
 ============
 
-ASP.NET Core (previously ASP.NET 5) changes the way dependency injection frameworks have previously integrated into ASP.NET execution. Previously, each functionality - MVC, Web API, etc. - had its own "dependency resolver" mechanism and just slightly different ways to hook in. ASP.NET Core introduces a `conforming container <http://blog.ploeh.dk/2014/05/19/conforming-container/>`__ mechanism via `Microsoft.Extensions.DependencyInjection <https://github.com/aspnet/DependencyInjection>`_, including a unified notion of request lifetime scope, service registration, and so forth.
+ASP.NET Core (previously ASP.NET 5) changes the way dependency injection frameworks have previously integrated into ASP.NET execution. Previously, each functionality - MVC, Web API, etc. - had its own "dependency resolver" mechanism and just slightly different ways to hook in. ASP.NET Core introduces a `conforming container <https://blog.ploeh.dk/2014/05/19/conforming-container/>`__ mechanism via `Microsoft.Extensions.DependencyInjection <https://github.com/aspnet/DependencyInjection>`_, including a unified notion of request lifetime scope, service registration, and so forth.
 
 Further, as of ASP.NET Core 3.0, there's a "generic app hosting" mechanism in play that can be used in non-ASP.NET Core apps.
 
@@ -274,7 +274,7 @@ Here are some helpful links into the ASP.NET Core documentation with specific in
 
 * `ASP.NET Core dependency injection fundamentals <https://docs.asp.net/en/latest/fundamentals/dependency-injection.html>`_
 * `Controller injection <https://docs.asp.net/en/latest/mvc/controllers/dependency-injection.html>`_
-* `The Subtle Perils of Controller Dependency Injection in ASP.NET Core MVC <http://www.strathweb.com/2016/03/the-subtle-perils-of-controller-dependency-injection-in-asp-net-core-mvc/>`_
+* `The Subtle Perils of Controller Dependency Injection in ASP.NET Core MVC <https://www.strathweb.com/2016/03/the-subtle-perils-of-controller-dependency-injection-in-asp-net-core-mvc/>`_
 * `Filter injection <https://docs.asp.net/en/latest/mvc/controllers/filters.html#configuring-filters>`_
 * `View injection <https://docs.asp.net/en/latest/mvc/views/dependency-injection.html>`_
 * `Authorization requirement handlers injection <https://docs.asp.net/en/latest/security/authorization/dependencyinjection.html>`_
@@ -287,7 +287,7 @@ Differences From ASP.NET Classic
 
 If you've used Autofac's other :doc:`ASP.NET integration <aspnet>` then you may be interested in the key differences as you migrate to using ASP.NET Core.
 
-* **Use InstancePerLifetimeScope instead of InstancePerRequest.** In previous ASP.NET integration you could register a dependency as ``InstancePerRequest`` which would ensure only one instance of the dependency would be created per HTTP request. This worked because Autofac was in charge of :doc:`setting up the per-request lifetime scope <../faq/per-request-scope>`. With the introduction of ``Microsoft.Extensions.DependencyInjection``, the creation of per-request and other child lifetime scopes is now part of the `conforming container <http://blog.ploeh.dk/2014/05/19/conforming-container/>`__ provided by the framework, so all child lifetime scopes are treated equally - there's no special "request level scope" anymore. Instead of registering your dependencies ``InstancePerRequest``, use ``InstancePerLifetimeScope`` and you should get the same behavior. Note if you are creating *your own lifetime scopes* during web requests, you will get a new instance in these child scopes.
+* **Use InstancePerLifetimeScope instead of InstancePerRequest.** In previous ASP.NET integration you could register a dependency as ``InstancePerRequest`` which would ensure only one instance of the dependency would be created per HTTP request. This worked because Autofac was in charge of :doc:`setting up the per-request lifetime scope <../faq/per-request-scope>`. With the introduction of ``Microsoft.Extensions.DependencyInjection``, the creation of per-request and other child lifetime scopes is now part of the `conforming container <https://blog.ploeh.dk/2014/05/19/conforming-container/>`__ provided by the framework, so all child lifetime scopes are treated equally - there's no special "request level scope" anymore. Instead of registering your dependencies ``InstancePerRequest``, use ``InstancePerLifetimeScope`` and you should get the same behavior. Note if you are creating *your own lifetime scopes* during web requests, you will get a new instance in these child scopes.
 * **No more DependencyResolver.** Other ASP.NET integration mechanisms required setting up a custom Autofac-based dependency resolver in various locations. With ``Microsoft.Extensions.DependencyInjection`` and the ``Startup.ConfigureServices`` method, you now just return the ``IServiceProvider`` and "magic happens." Within controllers, classes, etc. if you need to manually do service location, get an ``IServiceProvider``.
 * **No special middleware.** The :doc:`OWIN integration <owin>` previously required registration of a special Autofac middleware to manage the request lifetime scope. ``Microsoft.Extensions.DependencyInjection`` does the heavy lifting now, so there's no additional middleware to register.
 * **No manual controller registration.** You used to be required to register all of your controllers with Autofac so DI would work. The ASP.NET Core framework now automatically passes all controllers through service resolution so you don't have to do that.
@@ -325,7 +325,7 @@ You can change this by specifying ``AddControllersAsServices()`` when you regist
       }
     }
 
-There is a more detailed article `with a walkthrough on Filip Woj's blog <http://www.strathweb.com/2016/03/the-subtle-perils-of-controller-dependency-injection-in-asp-net-core-mvc/>`_. Note one of the commenters there `found some changes based on how RC2 handles controllers as services <http://www.strathweb.com/2016/03/the-subtle-perils-of-controller-dependency-injection-in-asp-net-core-mvc/#comment-2702995712>`_.
+There is a more detailed article `with a walkthrough on Filip Woj's blog <https://www.strathweb.com/2016/03/the-subtle-perils-of-controller-dependency-injection-in-asp-net-core-mvc/>`_. Note one of the commenters there `found some changes based on how RC2 handles controllers as services <https://www.strathweb.com/2016/03/the-subtle-perils-of-controller-dependency-injection-in-asp-net-core-mvc/#comment-2702995712>`_.
 
 Multitenant Support
 ===================

--- a/docs/integration/aspnetcore.rst
+++ b/docs/integration/aspnetcore.rst
@@ -263,7 +263,7 @@ This means you don't necessarily have to use :doc:`Autofac configuration <../con
       }
     }
 
-This is a feature of the application hosting in ASP.NET Core - it is not an Autofac behavior. The `StartupLoader class in ASP.NET Core <https://github.com/aspnet/Hosting/blob/rel/1.1.0/src/Microsoft.AspNetCore.Hosting/Internal/StartupLoader.cs>`_ is what locates the methods to call during app startup. Check that class out if you want a more in-depth understanding of how this works.
+This is a feature of the application hosting in ASP.NET Core - it is not an Autofac behavior. The `StartupLoader class in ASP.NET Core <https://github.com/dotnet/aspnetcore/blob/main/src/Hosting/Hosting/src/Internal/StartupLoader.cs>`_ is what locates the methods to call during app startup. Check that class out if you want a more in-depth understanding of how this works.
 
 Dependency Injection Hooks
 ==========================
@@ -518,4 +518,4 @@ Using a child lifetime scope as the root is not compatible with multitenant supp
 Example
 =======
 
-There is an example project showing ASP.NET Core integration `in the Autofac examples repository <https://github.com/autofac/Examples/tree/master/src/AspNetCoreExample>`_.
+There is an example project showing ASP.NET Core integration `in the Autofac examples repository <https://github.com/autofac/Examples/tree/main/src/AspNetCoreExample>`_.

--- a/docs/integration/aspnetcore.rst
+++ b/docs/integration/aspnetcore.rst
@@ -154,7 +154,7 @@ In your Startup class (which is basically the same across all the versions of AS
       {
         // In ASP.NET Core 3.x, using `Host.CreateDefaultBuilder` (as in the preceding Program.cs snippet) will
         // set up some configuration for you based on your appsettings.json and environment variables. See "Remarks" at
-        // https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.host.createdefaultbuilder for details.
+        // https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.host.createdefaultbuilder for details.
         this.Configuration = configuration;
       }
 

--- a/docs/integration/azurefunctions.rst
+++ b/docs/integration/azurefunctions.rst
@@ -4,7 +4,7 @@ Azure Functions
 
 Azure Functions supports dependency injection with the Microsoft dependency injection framework out of the box, but you can make it work with Autofac with a bit of bootstrapping code.
 
-We recommend reading the `official Microsoft documentation <https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection>`_ for an overview of dependency injection in the context of Azure Functions.
+We recommend reading the `official Microsoft documentation <https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection>`_ for an overview of dependency injection in the context of Azure Functions.
 
 .. contents::
   :local:

--- a/docs/integration/blazor.rst
+++ b/docs/integration/blazor.rst
@@ -4,7 +4,7 @@ Blazor
 
 
 
-`ASP.NET Core Blazor <https://docs.microsoft.com/en-gb/aspnet/core/blazor/>`_ uses the generic app hosting in ASP.NET Core 3+ but the two `hosting models <https://docs.microsoft.com/en-gb/aspnet/core/blazor/hosting-models>`_ have slightly different integrations.
+`ASP.NET Core Blazor <https://learn.microsoft.com/en-us/aspnet/core/blazor/>`_ uses the generic app hosting in ASP.NET Core 3+ but the two `hosting models <https://learn.microsoft.com/en-us/aspnet/core/blazor/hosting-models>`_ have slightly different integrations.
 
 **Server-side** implementations are configured in exactly the same way as any other `ASP.NET Core 3 <aspnetcore>`_ application.
 
@@ -33,4 +33,4 @@ This example for WebAssembly works as of March 30, 2021 with .NET 5. Example:
     }
   }
 
-Once registered, Blazor components can use `dependency injection <https://docs.microsoft.com/en-gb/aspnet/core/blazor/dependency-injection>`_ via the `standard @inject Razor directive <https://docs.microsoft.com/en-us/aspnet/core/blazor/dependency-injection?view=aspnetcore-3.0#request-a-service-in-a-component>`_.
+Once registered, Blazor components can use `dependency injection <https://learn.microsoft.com/en-us/aspnet/core/blazor/dependency-injection>`_ via the `standard @inject Razor directive <https://learn.microsoft.com/en-us/aspnet/core/blazor/dependency-injection#request-a-service-in-a-component>`_.

--- a/docs/integration/mef.rst
+++ b/docs/integration/mef.rst
@@ -2,7 +2,7 @@
 Managed Extensibility Framework (MEF)
 =====================================
 
-The Autofac MEF integration allows you to expose extensibility points in your applications using the `Managed Extensibility Framework <https://msdn.microsoft.com/en-us/library/dd460648(VS.100).aspx>`_.
+The Autofac MEF integration allows you to expose extensibility points in your applications using the `Managed Extensibility Framework <https://learn.microsoft.com/en-us/dotnet/framework/mef/>`_.
 
 To use MEF in an Autofac application, you must reference the .NET framework ``System.ComponentModel.Composition.dll`` assembly and get the `Autofac.Mef <https://www.nuget.org/packages/Autofac.Mef/>`_ package from NuGet.
 

--- a/docs/integration/mvc.rst
+++ b/docs/integration/mvc.rst
@@ -281,7 +281,7 @@ If you are using MVC :doc:`as part of an OWIN application <owin>`, you need to:
 Using "Plugin" Assemblies
 =========================
 
-If you have controllers in a "plugin assembly" that isn't referenced by the main application `you'll need to register your controller plugin assembly with the ASP.NET BuildManager <http://www.paraesthesia.com/archive/2013/01/21/putting-controllers-in-plugin-assemblies-for-asp-net-mvc.aspx>`_.
+If you have controllers in a "plugin assembly" that isn't referenced by the main application `you'll need to register your controller plugin assembly with the ASP.NET BuildManager <https://www.paraesthesia.com/archive/2013/01/21/putting-controllers-in-plugin-assemblies-for-asp-net-mvc.aspx>`_.
 
 You can do this through configuration or programmatically.
 
@@ -346,11 +346,11 @@ Using the Current Autofac DependencyResolver
 
 Once you set the MVC ``DependencyResolver`` to an ``AutofacDependencyResolver``, you can use ``AutofacDependencyResolver.Current`` as a shortcut to getting the current dependency resolver and casting it to an ``AutofacDependencyResolver``.
 
-Unfortunately, there are some gotchas around the use of ``AutofacDependencyResolver.Current`` that can result in things not working quite right. Usually these issues arise by using a product like `Glimpse <http://getglimpse.com/>`_ or `Castle DynamicProxy <http://www.castleproject.org/projects/dynamicproxy/>`_ that "wrap" or "decorate" the dependency resolver to add functionality. If the current dependency resolver is decorated or otherwise wrapped/proxied, you can't cast it to ``AutofacDependencyResolver`` and there's no single way to "unwrap it" or get to the actual resolver.
+Unfortunately, there are some gotchas around the use of ``AutofacDependencyResolver.Current`` that can result in things not working quite right. Usually these issues arise by using a product like `Glimpse <http://getglimpse.com/>`_ or `Castle DynamicProxy <https://www.castleproject.org/projects/dynamicproxy/>`_ that "wrap" or "decorate" the dependency resolver to add functionality. If the current dependency resolver is decorated or otherwise wrapped/proxied, you can't cast it to ``AutofacDependencyResolver`` and there's no single way to "unwrap it" or get to the actual resolver.
 
 Prior to version 3.3.3 of the Autofac MVC integration, we tracked the current dependency resolver by dynamically adding it to the request lifetime scope. This got us around issues where we couldn't unwrap the ``AutofacDependencyResolver`` from a proxy... but it meant that ``AutofacDependencyResolver.Current`` would only work during a request lifetime - you couldn't use it in background tasks or at application startup.
 
-Starting with version 3.3.3, the logic for locating ``AutofacDependencyResolver.Current`` changed to first attempt to cast the current dependency resolver; then to specifically look for signs it was wrapped using `Castle DynamicProxy <http://www.castleproject.org/projects/dynamicproxy/>`_ and unwrap it via reflection. Failing that... we can't find the current ``AutofacDependencyResolver`` so we throw an ``InvalidOperationException`` with a message like:
+Starting with version 3.3.3, the logic for locating ``AutofacDependencyResolver.Current`` changed to first attempt to cast the current dependency resolver; then to specifically look for signs it was wrapped using `Castle DynamicProxy <https://www.castleproject.org/projects/dynamicproxy/>`_ and unwrap it via reflection. Failing that... we can't find the current ``AutofacDependencyResolver`` so we throw an ``InvalidOperationException`` with a message like:
 
     The dependency resolver is of type 'Some.Other.DependencyResolver' but was expected to be of type 'Autofac.Integration.Mvc.AutofacDependencyResolver'. It also does not appear to be wrapped using DynamicProxy from the Castle Project. This issue could be the result of a change in the DynamicProxy implementation or the use of a different proxy library to wrap the dependency resolver.
 

--- a/docs/integration/mvc.rst
+++ b/docs/integration/mvc.rst
@@ -394,4 +394,4 @@ The :doc:`per-request lifetime scope <../faq/per-request-scope>` topic outlines 
 Example
 =======
 
-There is an example project showing ASP.NET MVC integration `in the Autofac examples repository <https://github.com/autofac/Examples/tree/master/src/MvcExample>`_.
+There is an example project showing ASP.NET MVC integration `in the Autofac examples repository <https://github.com/autofac/Examples/tree/main/src/MvcExample>`_.

--- a/docs/integration/netcore.rst
+++ b/docs/integration/netcore.rst
@@ -2,7 +2,7 @@
 .NET Core
 ============
 
-.NET Core comes with a `conforming container <http://blog.ploeh.dk/2014/05/19/conforming-container/>`_ in the form of `Microsoft.Extensions.DependencyInjection <https://github.com/aspnet/DependencyInjection>`_. The ``Autofac.Extensions.DependencyInjection`` package implements the abstractions for this to provide DI via Autofac.
+.NET Core comes with a `conforming container <https://blog.ploeh.dk/2014/05/19/conforming-container/>`_ in the form of `Microsoft.Extensions.DependencyInjection <https://github.com/aspnet/DependencyInjection>`_. The ``Autofac.Extensions.DependencyInjection`` package implements the abstractions for this to provide DI via Autofac.
 
 The integration with :doc:`ASP.NET Core <aspnetcore>` is very similar to this since the whole framework has unified the abstraction around dependency injection. Our :doc:`ASP.NET Core integration docs<aspnetcore>` have more info on specific topics relating to ASP.NET Core (and generically hosted application) usage.
 

--- a/docs/integration/owin.rst
+++ b/docs/integration/owin.rst
@@ -86,4 +86,4 @@ If you want more control over when DI-enabled middleware is added to the pipelin
 Example
 =======
 
-There is an example project showing Web API in conjunction with OWIN self hosting `in the Autofac examples repository <https://github.com/autofac/Examples/tree/master/src/WebApiExample.OwinSelfHost>`_.
+There is an example project showing Web API in conjunction with OWIN self hosting `in the Autofac examples repository <https://github.com/autofac/Examples/tree/main/src/WebApiExample.OwinSelfHost>`_.

--- a/docs/integration/wcf.rst
+++ b/docs/integration/wcf.rst
@@ -366,6 +366,6 @@ Again, you only need to do this if you're decorating the service implementation 
 Example
 -------
 
-The Autofac example repository has a `WCF service implementation example <https://github.com/autofac/Examples/tree/master/src/WcfExample>`_ as well as `an MVC application that acts as a client for that service <https://github.com/autofac/Examples/tree/master/src/MvcExample>`_.
+The Autofac example repository has a `WCF service implementation example <https://github.com/autofac/Examples/tree/main/src/WcfExample>`_ as well as `an MVC application that acts as a client for that service <https://github.com/autofac/Examples/tree/main/src/MvcExample>`_.
 
-There are also examples showing a `multitenant WCF service <https://github.com/autofac/Examples/tree/master/src/MultitenantExample.WcfService>`_ and `associated client <https://github.com/autofac/Examples/tree/master/src/MultitenantExample.MvcApplication>`_ to illustrate how :doc:`multitenant service hosting <../advanced/multitenant>` works.
+There are also examples showing a `multitenant WCF service <https://github.com/autofac/Examples/tree/main/src/MultitenantExample.WcfService>`_ and `associated client <https://github.com/autofac/Examples/tree/main/src/MultitenantExample.MvcApplication>`_ to illustrate how :doc:`multitenant service hosting <../advanced/multitenant>` works.

--- a/docs/integration/wcf.rst
+++ b/docs/integration/wcf.rst
@@ -278,7 +278,7 @@ The alternative approach is to place a code file in your ``App_Code`` folder tha
       }
     }
 
-You can read more about ``AppInitialize()`` in "`How to Initialize Hosted WCF Services <https://docs.microsoft.com/en-us/archive/blogs/wenlong/how-to-initialize-hosted-wcf-services>`_".
+You can read more about ``AppInitialize()`` in "`How to Initialize Hosted WCF Services <https://learn.microsoft.com/en-us/archive/blogs/wenlong/how-to-initialize-hosted-wcf-services>`_".
 
 Self-Hosting
 ------------
@@ -337,15 +337,15 @@ Simulating a Request Lifetime Scope
 
 As noted earlier, **due to WCF internals, there is no explicit support in WCF for per-request lifetime dependencies.**
 
-The way Autofac hooks into WCF, it uses an `instance provider <https://msdn.microsoft.com/en-us/library/system.servicemodel.dispatcher.iinstanceprovider(v=vs.110).aspx>`_ to resolve your service and dependencies. The instance provider makes use of the service instance context to track the lifetime scope in which your service and its dependencies live.
+The way Autofac hooks into WCF, it uses an `instance provider <https://learn.microsoft.com/en-us/dotnet/api/system.servicemodel.dispatcher.iinstanceprovider>`_ to resolve your service and dependencies. The instance provider makes use of the service instance context to track the lifetime scope in which your service and its dependencies live.
 
-What that boils down to: A lifetime scope is created based on the `instance context mode <https://msdn.microsoft.com/en-us/library/system.servicemodel.servicebehaviorattribute.instancecontextmode(v=vs.110).aspx>`_ of your service.
+What that boils down to: A lifetime scope is created based on the `instance context mode <https://learn.microsoft.com/en-us/dotnet/api/system.servicemodel.servicebehaviorattribute.instancecontextmode>`_ of your service.
 
-`If you leave it default, that's "per session." <https://msdn.microsoft.com/en-us/library/system.servicemodel.servicebehaviorattribute.instancecontextmode(v=vs.110).aspx>`_ One instance of your service will be created when a client calls it, and subsequent calls from that client will get the same instance.
+`If you leave it default, that's "per session." <https://learn.microsoft.com/en-us/dotnet/api/system.servicemodel.servicebehaviorattribute.instancecontextmode>`_ One instance of your service will be created when a client calls it, and subsequent calls from that client will get the same instance.
 
 However, if you want to simulate a per-request lifetime scope, you can:
 
-- Set your service to be instance-per-call using the `WCF ServiceBehaviorAttribute <https://msdn.microsoft.com/en-us/library/system.servicemodel.servicebehaviorattribute.instancecontextmode(v=vs.110).aspx>`_.
+- Set your service to be instance-per-call using the `WCF ServiceBehaviorAttribute <https://learn.microsoft.com/en-us/dotnet/api/system.servicemodel.servicebehaviorattribute.instancecontextmode>`_.
 - Register your service and dependencies to be instance-per-lifetime-scope.
 
 Doing those two things, you'll get a new lifetime scope for every call (because the WCF instance context will want to create a new service instance per call). Your service and dependencies will then be resolved as just one time within that instance context lifetime scope - effectively a per-request lifetime.

--- a/docs/integration/webapi.rst
+++ b/docs/integration/webapi.rst
@@ -516,4 +516,4 @@ The :doc:`per-request lifetime scope <../faq/per-request-scope>` topic outlines 
 Example
 =======
 
-There is an example project showing Web API in conjunction with OWIN self hosting `in the Autofac examples repository <https://github.com/autofac/Examples/tree/master/src/WebApiExample.OwinSelfHost>`_.
+There is an example project showing Web API in conjunction with OWIN self hosting `in the Autofac examples repository <https://github.com/autofac/Examples/tree/main/src/WebApiExample.OwinSelfHost>`_.

--- a/docs/integration/webapi.rst
+++ b/docs/integration/webapi.rst
@@ -373,7 +373,7 @@ Once you've implemented ``System.Web.Http.ModelBinding.IModelBinder`` to handle 
 Mark Parameters With ModelBinderAttribute
 -----------------------------------------
 
-Even if you have your model binder registered, you still need to mark your parameters with the ``[ModelBinder]`` attribute so Web API knows to use a model binder instead of a media type formatter to bind your model. You don't have to specify the model binder type anymore, but you do have to mark the parameter with the attribute. `This is also mentioned in the Web API documentation. <https://docs.microsoft.com/en-us/aspnet/web-api/overview/formats-and-model-binding/parameter-binding-in-aspnet-web-api>`_
+Even if you have your model binder registered, you still need to mark your parameters with the ``[ModelBinder]`` attribute so Web API knows to use a model binder instead of a media type formatter to bind your model. You don't have to specify the model binder type anymore, but you do have to mark the parameter with the attribute. `This is also mentioned in the Web API documentation. <https://learn.microsoft.com/en-us/aspnet/web-api/overview/formats-and-model-binding/parameter-binding-in-aspnet-web-api>`_
 
 .. sourcecode:: csharp
 

--- a/docs/integration/webforms.rst
+++ b/docs/integration/webforms.rst
@@ -80,7 +80,7 @@ The sections below go into further detail about what each of these features do a
 Add Modules to Web.config
 =========================
 
-The way that Autofac manages component lifetimes and adds dependency injection into the ASP.NET pipeline is through the use of `IHttpModule <https://msdn.microsoft.com/en-us/library/system.web.ihttpmodule.aspx>`_ implementations. You need to configure these modules in ``web.config``.
+The way that Autofac manages component lifetimes and adds dependency injection into the ASP.NET pipeline is through the use of `IHttpModule <https://learn.microsoft.com/en-us/dotnet/api/system.web.ihttpmodule>`_ implementations. You need to configure these modules in ``web.config``.
 
 The following snippet config shows the modules configured.
 

--- a/docs/integration/webforms.rst
+++ b/docs/integration/webforms.rst
@@ -302,4 +302,4 @@ The returned ``IInjectionBehavior`` can be one of the predefined ``NoInjection``
 Example
 =======
 
-There is an example project showing ASP.NET web forms integration `in the Autofac examples repository <https://github.com/autofac/Examples/tree/master/src/WebFormsExample>`_.
+There is an example project showing ASP.NET web forms integration `in the Autofac examples repository <https://github.com/autofac/Examples/tree/main/src/WebFormsExample>`_.

--- a/docs/lifetime/captive-dependencies.rst
+++ b/docs/lifetime/captive-dependencies.rst
@@ -2,7 +2,7 @@
 Captive Dependencies
 ====================
 
-A "captive dependency" occurs when a component intended to live for a *short* amount of time gets held by a component that lives for a *long* time. `This blog article from Mark Seemann <http://blog.ploeh.dk/2014/06/02/captive-dependency/>`_ does a good job of explaining the concept.
+A "captive dependency" occurs when a component intended to live for a *short* amount of time gets held by a component that lives for a *long* time. `This blog article from Mark Seemann <https://blog.ploeh.dk/2014/06/02/captive-dependency/>`_ does a good job of explaining the concept.
 
 **Autofac does not necessarily prevent you from creating captive dependencies.** You may find times when you get a resolution exception because of the way a captive is set up, but you won't always. Stopping captive dependencies is the responsibility of the developer.
 

--- a/docs/lifetime/disposal.rst
+++ b/docs/lifetime/disposal.rst
@@ -49,7 +49,7 @@ To take advantage of automatic deterministic disposal, your component must imple
 Asynchronous Disposal Support
 -----------------------------
 
-If your components' disposal behavior requires some I/O activity, such as flushing a buffer to a file, or sending a packet over the network to close a connection, then you may want to consider implementing the new .NET `IAsyncDisposable <https://docs.microsoft.com/en-us/dotnet/api/system.iasyncdisposable?view=netstandard-2.1>`_ interface.
+If your components' disposal behavior requires some I/O activity, such as flushing a buffer to a file, or sending a packet over the network to close a connection, then you may want to consider implementing the new .NET `IAsyncDisposable <https://learn.microsoft.com/en-us/dotnet/api/system.iasyncdisposable>`_ interface.
 
 In Autofac 5.0, support was added for the ``IAsyncDisposable`` interface, so lifetime scopes can now be disposed of asynchronously:
 

--- a/docs/lifetime/index.rst
+++ b/docs/lifetime/index.rst
@@ -9,7 +9,7 @@ You may recall from the :doc:`registration topic <../register/registration>` tha
 - How can I ensure a singleton is correctly shared in my application?
 - How do I control any of this?
 
-Note: Most of the content here is based on `Nick Blumhardt's Autofac lifetime primer <http://nblumhardt.com/2011/01/an-autofac-lifetime-primer/>`_. While some things in Autofac have changed over time, the concepts described there remain valid and may be helpful in understanding lifetime scopes.
+Note: Most of the content here is based on `Nick Blumhardt's Autofac lifetime primer <https://nblumhardt.com/2011/01/an-autofac-lifetime-primer/>`_. While some things in Autofac have changed over time, the concepts described there remain valid and may be helpful in understanding lifetime scopes.
 
 Basic Concepts and Terminology
 ==============================

--- a/docs/lifetime/index.rst
+++ b/docs/lifetime/index.rst
@@ -14,7 +14,7 @@ Note: Most of the content here is based on `Nick Blumhardt's Autofac lifetime pr
 Basic Concepts and Terminology
 ==============================
 
-The **lifetime** of a service is how long the service instance will live in your application - from the original instantiation to :doc:`disposal <disposal>`. For example, if you "new up" an object that implements `IDisposable <https://msdn.microsoft.com/en-us/library/system.idisposable.aspx>`_ and then later call ``Dispose()`` on it, the lifetime of that object is from the time you instantiated it all the way through disposal (or garbage collection if you didn't proactively dispose it).
+The **lifetime** of a service is how long the service instance will live in your application - from the original instantiation to :doc:`disposal <disposal>`. For example, if you "new up" an object that implements `IDisposable <https://learn.microsoft.com/en-us/dotnet/api/system.idisposable>`_ and then later call ``Dispose()`` on it, the lifetime of that object is from the time you instantiated it all the way through disposal (or garbage collection if you didn't proactively dispose it).
 
 .. sourcecode:: csharp
 

--- a/docs/owners.rst
+++ b/docs/owners.rst
@@ -22,7 +22,7 @@ Being an owner is accepting that trust and always trying your best to do the rig
 Code of Conduct
 ===============
 
-`Our code of conduct is posted on GitHub <https://github.com/autofac/Autofac/blob/develop/CODE_OF_CONDUCT.md>`_. All owners must follow the code of conduct. Owners are responsible for enforcing the code of conduct on each other and on contributors.
+`Our code of conduct is posted on GitHub <https://github.com/autofac/.github/blob/main/CODE_OF_CONDUCT.md>`_. All owners must follow the code of conduct. Owners are responsible for enforcing the code of conduct on each other and on contributors.
 
 Responsibilities
 ================

--- a/docs/register/registration.rst
+++ b/docs/register/registration.rst
@@ -216,7 +216,7 @@ While Autofac offers :doc:`a more first-class approach to property injection <pr
 
 The ``ResolveOptional`` method will try to resolve the value but won't throw an exception if the service isn't registered. (You will still get an exception if the service is registered but can't properly be resolved.) This is one of the options for :doc:`resolving a service <../resolve/index>`.
 
-**Property injection is not recommended in the majority of cases.** Alternatives like `the Null Object pattern <http://en.wikipedia.org/wiki/Null_Object_pattern>`_, overloaded constructors or constructor parameter default values make it possible to create cleaner, "immutable" components with optional dependencies using constructor injection.
+**Property injection is not recommended in the majority of cases.** Alternatives like `the Null Object pattern <https://en.wikipedia.org/wiki/Null_Object_pattern>`_, overloaded constructors or constructor parameter default values make it possible to create cleaner, "immutable" components with optional dependencies using constructor injection.
 
 .. _register-select-impl-by-parameter:
 

--- a/docs/register/scanning.rst
+++ b/docs/register/scanning.rst
@@ -181,7 +181,7 @@ When using assembly scanning with IIS applications, you can run into a little tr
 
 When hosting applications in IIS all assemblies are loaded into the ``AppDomain`` when the application first starts, but **when the AppDomain is recycled by IIS the assemblies are then only loaded on demand.**
 
-To avoid this issue use the `GetReferencedAssemblies() <https://msdn.microsoft.com/en-us/library/system.web.compilation.buildmanager.getreferencedassemblies.aspx>`_ method on `System.Web.Compilation.BuildManager <https://msdn.microsoft.com/en-us/library/system.web.compilation.buildmanager.aspx>`_ to get a list of the referenced assemblies instead:
+To avoid this issue use the `GetReferencedAssemblies() <https://learn.microsoft.com/en-us/dotnet/api/system.web.compilation.buildmanager.getreferencedassemblies>`_ method on `System.Web.Compilation.BuildManager <https://learn.microsoft.com/en-us/dotnet/api/system.web.compilation.buildmanager>`_ to get a list of the referenced assemblies instead:
 
 .. sourcecode:: csharp
 

--- a/docs/resolve/relationships.rst
+++ b/docs/resolve/relationships.rst
@@ -10,7 +10,7 @@ For example, when Autofac is injecting a constructor parameter of type ``IEnumer
 
 Note: To override this default behavior *it is still possible to register explicit implementations of these types*.
 
-[Content on this document based on Nick Blumhardt's blog article `The Relationship Zoo <http://nblumhardt.com/2010/01/the-relationship-zoo/>`_.]
+[Content on this document based on Nick Blumhardt's blog article `The Relationship Zoo <https://nblumhardt.com/2010/01/the-relationship-zoo/>`_.]
 
 
 Supported Relationship Types

--- a/docs/troubleshooting/symbols.rst
+++ b/docs/troubleshooting/symbols.rst
@@ -2,9 +2,9 @@
 Symbols and Sources
 ===================
 
-Autofac packages have been updated `to use Source Link <https://github.com/dotnet/sourcelink>`_ so you can debug right from your code into the Autofac source. Packages may have the symbols right inside or they may be in the `NuGet Symbol Server <https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#nugetorg-symbol-server>`_.
+Autofac packages have been updated `to use Source Link <https://github.com/dotnet/sourcelink>`_ so you can debug right from your code into the Autofac source. Packages may have the symbols right inside or they may be in the `NuGet Symbol Server <https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#nugetorg-symbol-server>`_.
 
-**In Visual Studio**, there's an option to enable searching the NuGet symbol server. `See the documentation from Microsoft explaining how to configure Visual Studio to make symbol servers work. <https://docs.microsoft.com/en-us/visualstudio/debugger/specify-symbol-dot-pdb-and-source-files-in-the-visual-studio-debugger>`_
+**In Visual Studio**, there's an option to enable searching the NuGet symbol server. `See the documentation from Microsoft explaining how to configure Visual Studio to make symbol servers work. <https://learn.microsoft.com/en-us/visualstudio/debugger/specify-symbol-dot-pdb-and-source-files-in-the-visual-studio-debugger>`_
 
 **In VS Code**, you may need to set the debugging options up in ``settings.json`` or ``launch.json``.
 

--- a/docs/troubleshooting/tracing.rst
+++ b/docs/troubleshooting/tracing.rst
@@ -8,7 +8,7 @@ Autofac provides diagnostics support that allows you to monitor and trace the re
 
     **Tracing isn't free.** You will get better performance if you **don't** have a diagnostic listener attached to the container. Further, tracers like ``DefaultDiagnosticTracer`` that generate a full trace of an operation will increase memory and resource usage as they have to hold onto data during the entire resolve operation in order to generate a complete trace. It is recommended you only use diagnostics in a non-production environment; or use diagnostics listeners that handle individual events without tracking full operations.
 
-Autofac 6.0 introduced diagnostics support in the form of `System.Diagnostics.DiagnosticSource <https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.diagnosticsource?view=netcore-3.1>`_. This allows you to intercept diagnostic events from Autofac.
+Autofac 6.0 introduced diagnostics support in the form of `System.Diagnostics.DiagnosticSource <https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.diagnosticsource>`_. This allows you to intercept diagnostic events from Autofac.
 
 If you're interested in metrics for performance measurement, :doc:`Autofac also provides metrics <metrics>`.
 


### PR DESCRIPTION
Three commits: GitHub links (verified), Microsoft doc links (needs your eye on the table), and an https sweep (droppable on its own).

## Why

**Twelve GitHub URLs were 404.** I confirmed each against the GitHub API rather than assuming. Ten pointed at `master`: the Examples repo and the org `.github` repo were both renamed to `main`, which broke every example link on the MVC, Web API, Web Forms, WCF, OWIN, ASP.NET Core and multitenant pages, plus both links in the contributor guide. Two more were wrong independently of that — `owners.rst` linked the code of conduct at `autofac/Autofac/blob/develop/CODE_OF_CONDUCT.md`, where no such file exists (it lives only in the org `.github` repo), and `aspnetcore.rst` linked `StartupLoader.cs` in `aspnet/Hosting` pinned to `rel/1.1.0`, a repo that has since folded into `dotnet/aspnetcore`.

**Twenty-nine links pointed at retired Microsoft hosts** — `msdn.microsoft.com` and `docs.microsoft.com`, both superseded by `learn.microsoft.com`. Three also pinned a stale `?view=` (`netcore-3.1`, `netstandard-2.1`, `aspnetcore-3.0`), so they served old documentation for types that still exist. Three Blazor links used an `en-gb` locale where every other link in the docs uses `en-us`.

**Thirty-four links used `http`** on hosts that have been https-only for years.

## Verification, and its limits

Everything GitHub I could check, and did: all 58 GitHub URLs in the docs went through the API. 12 came back broken, and every replacement path was confirmed to exist before I used it — including all eight `Examples/src/*` directories on `main`, which matters since that repo is being edited in parallel.

**I could not verify the Microsoft targets.** External fetches aren't available where this was authored, so those paths are canonical forms, not confirmations. That's why the mapping is spelled out here rather than buried in the diff:

| From | To |
|---|---|
| `msdn…/system.idisposable.aspx` | `learn…/dotnet/api/system.idisposable` |
| `msdn…/system.componentmodel.composition.metadataattributeattribute.aspx` | `learn…/dotnet/api/system.componentmodel.composition.metadataattributeattribute` |
| `msdn…/system.servicemodel.dispatcher.idispatchmessageinspector.afterreceiverequest.aspx` | `learn…/dotnet/api/system.servicemodel.dispatcher.idispatchmessageinspector.afterreceiverequest` |
| `msdn…/system.servicemodel.dispatcher.iinstanceprovider(v=vs.110).aspx` | `learn…/dotnet/api/system.servicemodel.dispatcher.iinstanceprovider` |
| `msdn…/system.servicemodel.servicebehaviorattribute.instancecontextmode(v=vs.110).aspx` | `learn…/dotnet/api/system.servicemodel.servicebehaviorattribute.instancecontextmode` |
| `msdn…/system.web.compilation.buildmanager.aspx` | `learn…/dotnet/api/system.web.compilation.buildmanager` |
| `msdn…/system.web.compilation.buildmanager.getreferencedassemblies.aspx` | `learn…/dotnet/api/system.web.compilation.buildmanager.getreferencedassemblies` |
| `msdn…/system.web.ihttpmodule.aspx` | `learn…/dotnet/api/system.web.ihttpmodule` |
| `msdn…/system.web.sessionstate.sessionstatemodule.end.aspx` | `learn…/dotnet/api/system.web.sessionstate.sessionstatemodule.end` |
| `msdn…/dd460648(VS.100).aspx` (MEF) | `learn…/dotnet/framework/mef/` |
| `msdn…/vstudio/2fc472t2.aspx` (binding redirects) | `learn…/dotnet/framework/configure-apps/redirect-assembly-versions` |
| `msdn…/wd40t7ad.aspx` (strong naming) | `learn…/dotnet/standard/assembly/strong-named` |
| `msdn…/yfsftwz6(v=vs.110).aspx` (qualified type names) | `learn…/dotnet/framework/reflection-and-codedom/specifying-fully-qualified-type-names` |

The nine API topics follow the canonical `/dotnet/api/<lowercased type>` form, which I'd treat as safe. The four conceptual ones are the ones worth a glance.

The 16 `docs.microsoft.com` links are host swaps with the path preserved, apart from dropping the three stale `?view=` pins and normalizing `en-gb` to `en-us`.

Rendered `learn.microsoft.com` links go from 11 to 45. `sphinx -b html -W --keep-going`, `pre-commit run --all-files` and `npm run lint` are clean, and I spot-checked the built HTML to confirm the rewritten URLs still render as links with their original text.

## Deliberately deferred

Not oversights — remapping these now would be work thrown away, since the surrounding content is already scheduled to change:

- **4 msdn links** in the `.NET Native` section of the trimming page and the PCL FAQ. Both cover retired platforms and are slated for removal.
- **10 `docs.asp.net` and `www.asp.net` links** in `aspnetcore.rst`, `owin.rst` and `signalr.rst`. That whole ASP.NET Core link list is being rewritten, and the Katana and SignalR targets no longer have direct equivalents.
- **Dead hosts** — `getglimpse.com`, `code.google.com/p/slimtune`, `readify.net`, `ciclo.pt`, `continuousit.com`, `owin.org`, `blogs.msdn.microsoft.com` — each needs a content decision (replace or delete) rather than a URL swap, and they land with the sections that reference them.
