### PR TITLE
Document DynamicProxy 8.x interception behavior

### DIFF
--- a/docs/advanced/interceptors.rst
+++ b/docs/advanced/interceptors.rst
@@ -4,7 +4,7 @@ Type Interceptors
 
 `Castle.Core <https://github.com/castleproject/Core>`_, part of `the Castle Project <https://castleproject.org>`_, provides a method interception framework called "DynamicProxy."
 
-The ``Autofac.Extras.DynamicProxy`` integration package enables method calls on Autofac components to be intercepted by other components. Common use-cases are transaction handling, logging, and declarative security. You can use ``Autofac.Extras.DynamicProxy2`` for Autofac versions up to 4.0.0
+The ``Autofac.Extras.DynamicProxy`` integration package enables method calls on Autofac components to be intercepted by other components. Common use-cases are transaction handling, logging, and declarative security.
 
 Enabling Interception
 =====================
@@ -82,9 +82,37 @@ When you register a type being intercepted, you have to mark the type at registr
 
 Under the covers, ``EnableInterfaceInterceptors()`` creates an interface proxy that performs the interception, while ``EnableClassInterceptors()`` dynamically subclasses the target component to perform interception of virtual methods.
 
-Both techniques can be used in conjunction with the assembly scanning support, so you can configure batches of components using the same methods.
+Both techniques can be used in conjunction with :doc:`assembly scanning <../register/scanning>`, so you can configure batches of components using the same methods. That includes closed generics discovered with ``AsClosedTypesOf()``:
 
-**Special case: WCF proxy and remoting objects** While WCF proxy objects *look* like interfaces, the ``EnableInterfaceInterceptors()`` mechanism won't work because, behind the scenes, the .NET desktop framework is actually using a ``System.Runtime.Remoting.TransparentProxy`` object that behaves like the interface. As of v6.0.0 of ``Autofac.Extras.DynamicProxy`` the ability to intercept ``TransparentProxy`` objects was removed in an effort to improve cross-platform support.
+.. sourcecode:: csharp
+
+    builder.RegisterAssemblyTypes(typeof(Program).Assembly)
+           .AsClosedTypesOf(typeof(ICommandHandler<,>))
+           .EnableInterfaceInterceptors()
+           .InterceptedBy(typeof(CallLogger));
+
+**Special case: WCF proxy and remoting objects.** While WCF proxy objects *look* like interfaces, the ``EnableInterfaceInterceptors()`` mechanism won't work because, behind the scenes, the .NET desktop framework is actually using a ``System.Runtime.Remoting.TransparentProxy`` object that behaves like the interface. As of v6.0.0 of ``Autofac.Extras.DynamicProxy`` the ability to intercept ``TransparentProxy`` objects was removed in an effort to improve cross-platform support.
+
+Intercept Only Some Types
+-------------------------
+
+Both ``EnableClassInterceptors()`` and ``EnableInterfaceInterceptors()`` accept an optional ``Func<Type, bool>`` predicate. Types for which it returns ``false`` are registered without a proxy. This matters most with assembly scanning, where you want interception on some of the scanned types and not others.
+
+.. sourcecode:: csharp
+
+    var builder = new ContainerBuilder();
+    builder.RegisterType<CallLogger>();
+
+    // Only types marked with [InterceptMe] get a proxy. Everything
+    // else the scan picks up is registered as-is.
+    builder.RegisterAssemblyTypes(typeof(Program).Assembly)
+           .As<IPublicInterface>()
+           .EnableInterfaceInterceptors(t => t.IsDefined(typeof(InterceptMeAttribute), false))
+           .InterceptedBy(typeof(CallLogger));
+
+**The predicate runs at a different point for each mechanism.** Class interception evaluates it once per candidate type, as registrations are built. Interface interception evaluates it against the resolved implementation type, so the decision happens per resolve.
+
+When interface interception skips a type you get the original instance back rather than a pass-through proxy, so excluded types carry no interception cost at all.
 
 .. _associate_interceptors:
 
@@ -181,6 +209,13 @@ Class Interceptors and UsingConstructor
 
 If you are using class interceptors via ``EnableClassInterceptors()`` then avoid using the constructor selector ``UsingConstructor()`` with it. When class interception is enabled, the generated proxy adds some new constructors that also take the set of interceptors you want to use. When you specify ``UsingConstructor()`` you'll bypass this logic and your interceptors won't be used.
 
+Optional Constructor Arguments
+------------------------------
+
+Optional constructor arguments work on class-intercepted registrations. The generated proxy constructor mirrors the parameters of the type being proxied but not their default values, so Autofac reads the defaults off the proxied type and supplies them on its behalf. Values passed to the resolve operation, values configured on the registration, and services available from the container all still take precedence, so binding behaves the same as it would without a proxy.
+
+This can change which constructor gets selected. A constructor with an optional argument that previously couldn't be bound now can be, so Autofac may pick it where a narrower overload used to win. Given ``MyService(IThing thing)`` and ``MyService(IThing thing, int retries = 5)``, the two-argument constructor is chosen.
+
 Known Issues
 ============
 
@@ -189,23 +224,20 @@ Asynchronous Method Interception
 
 Castle interceptors only expose a synchronous mechanism to intercept methods - there's no explicit ``async``/``await`` sort of support. However, given ``async``/``await`` is just syntactic sugar around returning ``Task`` objects, you can use ``Task`` and ``ContinueWith()`` sorts of methods in your interceptor. `This issue <https://github.com/castleproject/Core/issues/107>`_ shows an example of that. Alternatively, there are `helper libraries <https://github.com/JSkimming/Castle.Core.AsyncInterceptor>`_ that make async work easier.
 
+Enum Keys with Class Interception
+---------------------------------
+
+Using :doc:`KeyFilter <keyed-services>` with an **enum** key does not work together with **class** interception. Castle DynamicProxy reproduces the attribute argument on the generated proxy constructor as the enum's underlying integer type, so the key stops matching the registered keyed service and resolution fails.
+
+Use a string key, or use interface interception instead - neither goes through the conversion. `The upstream Castle issue tracks this. <https://github.com/castleproject/Core/issues/748>`_
+
 Castle.Core Versioning
 ----------------------
 
-As of Castle.Core 4.2.0, the Castle.Core *NuGet package version* updates but the *assembly version* does not. Further, the assembly version in Castle.Core 4.1.0 matched the package (4.1.0.0) but the 4.2.0 package *back-versioned* to 4.0.0.0. In full .NET framework projects any confusion around Castle.Core versioning can be solved by adding an assembly binding redirect to force use of Castle.Core 4.0.0.0.
+Castle.Core pins its *assembly* version to ``<major>.0.0.0`` and leaves it there for the life of that major version - every Castle.Core 5.x package, 5.1.0 through 5.2.1, ships assembly version ``5.0.0.0``. Updating the package within a major version needs no binding redirect, because the assembly identity never moved.
 
-Unfortunately, .NET core doesn't have assembly binding redirects so if you have a *transitive* dependency on Castle.Core through a library like Autofac.Extras.DynamicProxy and you *also* have a direct dependency on Castle.Core, you may see something like:
+Straddling a major version is what breaks. ``Autofac.Extras.DynamicProxy`` 8.x depends on Castle.Core 5.x, so if something else in your application was built against Castle.Core 4.x you can see:
 
-``System.IO.FileLoadException: Could not load file or assembly 'Castle.Core, Version=4.1.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc'. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)``
+``System.IO.FileLoadException: Could not load file or assembly 'Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc'. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)``
 
-This happens because of the back-versioned assembly.
-
-**Be sure you have the latest Autofac.Extras.DynamicProxy.** We do our best to fix as much as possible from the Autofac end. An update to that and/or Castle.Core may help.
-
-If that doesn't work, there are two solutions:
-
-One, you can remove your direct Castle.Core reference. The transitive references should sort themselves out.
-
-Two, if you can't remove your direct reference or removing it doesn't work... all of the direct dependencies you have will need to update to version 4.2.0 or higher of Castle.Core. You'll have to file issues with those projects; it's not something Autofac can fix for you.
-
-`For reference, here's the Castle.Core issue discussing this challenge. <https://github.com/castleproject/Core/issues/288>`_
+On .NET Framework a binding redirect to ``5.0.0.0`` may get you past it, but Castle 5 removed API that Castle 4 exposed, so a redirect only holds if the library on the older version doesn't reach for anything that went away. Modern .NET has no binding redirects, so there the only real fix is getting every direct and transitive dependency onto Castle.Core 5.x - which sometimes means filing issues with projects still on 4.x. `The Castle.Core issue discussing this versioning policy has the background. <https://github.com/castleproject/Core/issues/288>`_


### PR DESCRIPTION
First of the content PRs. Covers the interception page only.

## Why

`Autofac.Extras.DynamicProxy` 8.0.0 and 8.1.0 shipped four behaviors that never reached the docs, and the page still carried guidance written against Castle.Core 4.

## What's added

**Conditional interception.** Both `EnableClassInterceptors()` and `EnableInterfaceInterceptors()` take an optional `Func<Type, bool>`. The example uses the motivating case — attribute-driven selection during assembly scanning — taken from `ConditionalInterceptionFixture`.

The timing difference is documented because it's not guessable from the signature: class interception evaluates the predicate once per candidate type as registrations are built, interface interception evaluates it per resolve against the implementation type. Also noted that a skipped type returns the original instance rather than a pass-through proxy, so exclusion costs nothing.

**Interface interception with `AsClosedTypesOf()`**, which previously threw.

**Optional constructor arguments on class-intercepted registrations**, including the consequence worth knowing: a constructor that couldn't previously be bound now can be, so Autofac may pick a wider overload than before.

**Enum `[KeyFilter]` keys under class interception** as a known issue. Castle reproduces the attribute argument as the enum's underlying integer type, so the key stops matching the registered keyed service. Workarounds are a string key or interface interception.

## The Castle.Core section: plan was wrong

My plan had this section down for deletion as obsolete. Before deleting it I checked the actual assemblies, and the back-versioning it describes **is still in force**:

```text
package 5.1.0   ->  assembly version 5.0.0.0
package 5.1.1   ->  assembly version 5.0.0.0
package 5.2.1   ->  assembly version 5.0.0.0
```

So it's rewritten for the 5.x reality instead of removed. Two things change substantively:

- Updating Castle.Core *within* a major version needs no binding redirect, because the assembly identity never moves. The old text implied redirects were routinely needed.
- The failure mode is straddling majors. `Autofac.Extras.DynamicProxy` 8.x wants Castle.Core 5.x, and the packaged floors confirm the boundary: 6.0.0 → 4.4.0, 7.1.0 → 5.1.1, 8.x → 5.2.1.

It also no longer presents a binding redirect as a general fix, since Castle 5 removed API Castle 4 exposed — a redirect only holds if the older library doesn't reach for anything that went away.

## Also

Dropped the pointer to `Autofac.Extras.DynamicProxy2`, irrelevant since Autofac 4, and fixed a missing period after the bolded "Special case: WCF proxy and remoting objects" lead-in.

## Verification

Every API signature was read out of `RegistrationExtensions.cs` rather than inferred from release notes, and the predicate semantics come from the XML docs plus `ConditionalInterceptionFixture`, `OpenGenericInterfaceInterceptionFixture` and `ClassInterceptorsWithOptionalParametersFixture`.

`sphinx -b html -W --keep-going` and `doc8` clean, and I read the rendered HTML to confirm the new sections come out right. The `-W` build earned its keep here — it caught a section underline I'd left one character short.
