### PR TITLE
Document composite keying, pool providers, and decorator ownership

### DIFF
--- a/docs/advanced/adapters-decorators.rst
+++ b/docs/advanced/adapters-decorators.rst
@@ -155,6 +155,8 @@ You can use that context to make decisions in your decorators if you want. It ca
 
 **You cannot specify a lifetime scope on a decorator.** The lifetime of a decorator is tied to the lifetime of the thing it decorates. The service and all decorators get disposed at the same time. If you decorate a singleton, all the decorators are also going to be singletons. If you decorate something that's instance per request (e.g., in a web app) the decorators will also live for the whole request.
 
+**Ownership follows the decorated component as well.** :doc:`Registering the decorated service as ExternallyOwned <../lifetime/disposal>` opts the whole chain out of disposal tracking - neither the decorated instance nor any decorator over it will be disposed when the scope ends. That holds however many decorators are stacked, since it's the ownership of the underlying component that governs.
+
 Classic Syntax
 --------------
 

--- a/docs/advanced/composites.rst
+++ b/docs/advanced/composites.rst
@@ -106,10 +106,39 @@ Composite wrappers can have their own additional dependencies, as well as use an
     public class MetaCompositeWrapper : ILogSink
     {
         // Access the metadata of each implementation.
-        public LazyCompositeWrapper(IEnumerable<Meta<ILogSink>> implementations)
+        public MetaCompositeWrapper(IEnumerable<Meta<ILogSink>> implementations)
         {
         }
     }
+
+Keyed Composites
+================
+
+By default a composite wraps the implementations registered *without* a key. If you also key the composite, resolving that key gives you a composite over just the implementations sharing it - so one composite type can serve several groups.
+
+.. sourcecode:: csharp
+
+    var builder = new ContainerBuilder();
+
+    builder.Register(ctx => new FileLogSink()).As<ILogSink>().Keyed<ILogSink>("disk");
+    builder.Register(ctx => new RollingFileLogSink()).As<ILogSink>().Keyed<ILogSink>("disk");
+    builder.Register(ctx => new DbLogSink()).As<ILogSink>().Keyed<ILogSink>("remote");
+
+    builder.RegisterComposite<CompositeLogSink, ILogSink>()
+           .Keyed<ILogSink>("disk")
+           .Keyed<ILogSink>("remote");
+
+    var container = builder.Build();
+
+    // Composite over every unkeyed implementation.
+    var all = container.Resolve<ILogSink>();
+
+    // Composite over only the implementations keyed "disk".
+    var disk = container.ResolveKeyed<ILogSink>("disk");
+
+Without the extra ``Keyed`` calls, ``ResolveKeyed<ILogSink>("disk")`` returns the last implementation registered under that key rather than a composite. You still get only one unkeyed composite registration; keying is what opts a composite into this behavior.
+
+This works through the :doc:`implicit relationship types <../resolve/relationships>` too, so a composite taking ``IEnumerable<Lazy<ILogSink>>`` gets the keyed subset just the same.
 
 Metadata
 ========
@@ -137,7 +166,7 @@ Decorators
 
 When using the composite pattern, decorators are **only applied to the individual implementations**, and **not** to the composite itself.
 
-So, if you register a decorator for ``ILogSink``, and have a composite registration with implementations ``FileLogSink`` and ``DbLogSink``, when you resolve ``ILogSink`` ``FileLogSink`` and ``DbLogSink`` **will** be decorated, but your composite wrapper **will not** be decorated.
+So, if you register a decorator for ``ILogSink``, and have a composite registration with implementations ``FileLogSink`` and ``DbLogSink``, when you resolve ``ILogSink``, ``FileLogSink`` and ``DbLogSink`` **will** be decorated, but your composite wrapper **will not** be decorated.
 
 Composites and Collections
 ==========================

--- a/docs/advanced/pooled-instances.rst
+++ b/docs/advanced/pooled-instances.rst
@@ -218,3 +218,34 @@ You can then use this policy when registering your pool:
     builder.RegisterType<MyCustomConnection>()
             .As<ICustomConnection>()
             .PooledInstancePerLifetimeScope(new BlockingPolicy<MyCustomConnection>(100));
+
+If the policy itself needs dependencies, pass a factory instead of an instance. The factory receives an ``IComponentContext`` so it can resolve them:
+
+.. sourcecode:: csharp
+
+    builder.RegisterType<MyCustomConnection>()
+            .As<ICustomConnection>()
+            .PooledInstancePerLifetimeScope(
+                ctx => new BlockingPolicy<MyCustomConnection>(ctx.Resolve<IPoolSettings>().MaxConcurrency));
+
+Controlling Where Instances Are Stored
+======================================
+
+A policy decides *what happens* when an instance is fetched or returned. If you also need to control *where instances live* - how the pool is sized, and when it evicts - supply an ``ObjectPoolProvider``:
+
+.. sourcecode:: csharp
+
+    builder.RegisterType<MyCustomConnection>()
+            .As<ICustomConnection>()
+            .PooledInstancePerLifetimeScope(ctx => ctx.Resolve<ObjectPoolProvider>());
+
+The provider factory runs once, resolved from the scope that owns the pool, so it can pull dependencies out of the container. Autofac still constructs the pooled instances and still raises the ``IPooledComponent`` callbacks; the provider only owns storage and eviction. There are overloads that take a policy factory and a provider factory together, and matching ones on ``PooledInstancePerMatchingLifetimeScope``.
+
+Handing over storage moves some responsibilities with it, and these are easy to get wrong:
+
+- **Pool capacity no longer applies.** Because the provider owns sizing, ``MaximumRetained`` on the policy stops having any effect.
+- **The pool must be thread-safe.** One pool is shared across every lifetime scope and thread that resolves the component.
+- **The pool disposes what it discards.** ``ObjectPool<T>.Return`` reports no result and there is no eviction callback, so instances the pool declines on return or evicts later are the pool's to dispose. Autofac cannot see those decisions.
+- If the pool implements ``IDisposable``, the container disposes it at shutdown.
+
+Unless you need one of those knobs, a :ref:`pool policy <pooled-instances-policies>` is the simpler place to customize behavior.


### PR DESCRIPTION
Second content PR. Three shipped features that had no documentation, one page each.

## Keyed composites — core 8.3.0

A composite only wraps implementations registered *without* a key. Keying the composite itself makes `ResolveKeyed` return a composite over just the implementations sharing that key, so one composite type can serve several groups.

The part worth stating explicitly, and now stated: **without the extra `Keyed` calls, a keyed resolve returns the last matching implementation rather than a composite.** That reads as a bug when you hit it, and it's the exact behavior the original request described.

## Custom pool storage — Autofac.Pooling 2.0.0

Pooled registrations can now take an `ObjectPoolProvider`, and policies can be supplied as factories so they can resolve their own dependencies.

The API is the easy half. The consequences of handing storage over are what needed writing down, and all four come from the XML remarks on the overload:

- **Pool capacity stops applying.** The provider owns sizing, so `MaximumRetained` no longer has any effect — surprising if you'd already set a capacity.
- **The pool must be thread-safe**, because one pool is shared across every lifetime scope and thread.
- **The pool owns disposal of what it discards.** `ObjectPool<T>.Return` reports no result and there's no eviction callback, so Autofac cannot see those decisions.
- If the pool is `IDisposable`, the container disposes it at shutdown.

The section closes by pointing back at pool policies as the simpler option, since a policy covers most customization without taking on any of the above.

## Decorator ownership — core 9.2.0

`ExternallyOwned` on a decorated service opts the *entire* decorator chain out of disposal tracking. Added directly beneath the existing note about decorator lifetime, which is where someone hitting this would already be reading.

## Also fixed

`composites.rst` had a constructor named `LazyCompositeWrapper` inside `class MetaCompositeWrapper` — one of the four class/constructor mismatches I found during the structural pass. Also the missing comma that unwrapping exposed, which I'd deliberately left out of #197 to keep that PR free of prose changes.

## Verification

Nothing here came from release notes alone:

- Keyed composite semantics from `CompositeTests.CanRegisterCompositeOfKeyedServices` and the relationship-type variant, plus the originating pull request.
- All 14 `Autofac.Pooling` extension signatures read out of `RegistrationExtensions.cs`; the caveats are its XML remarks restated in prose.
- Decorator ownership from `DecoratorNotDisposedWhenDecoratedServiceIsExternallyOwned` and `StackedDecoratorsNotDisposedWhenDecoratedServiceIsExternallyOwned` — the stacked test is what justifies the claim about chains of any depth.

`sphinx -b html -W --keep-going` and `doc8` clean, and I read the rendered HTML for all three sections.
