### PR TITLE
Add real-world middleware examples and document the Type overloads

### DIFF
--- a/docs/advanced/pipelines.rst
+++ b/docs/advanced/pipelines.rst
@@ -197,6 +197,115 @@ Just like with registration middleware, you can register middleware classes inst
 
     builder.RegisterServiceMiddleware<IMyService>(new MyServiceMiddleware());
 
+If the service type isn't known at compile time - you're looping over types found by a scan, say - there are overloads that take a ``Type`` instead of a generic parameter:
+
+.. code-block:: csharp
+
+    foreach (var serviceType in assembly.GetTypes().Where(t => t.IsInterface))
+    {
+        builder.RegisterServiceMiddleware(serviceType, PipelinePhase.ResolveRequestStart, (context, next) =>
+        {
+            next(context);
+        });
+    }
+
+Two optional arguments are worth knowing about. A ``descriptor`` names the middleware in :doc:`resolve traces <../troubleshooting/tracing>`, so a trace reads ``custom-middleware`` instead of ``anonymous``. A ``MiddlewareInsertionMode`` of ``StartOfPhase`` puts your middleware ahead of the other middleware in the same phase rather than after it.
+
+.. code-block:: csharp
+
+    builder.RegisterServiceMiddleware<IMyService>(
+        "tenant-resolution",
+        PipelinePhase.ScopeSelection,
+        MiddlewareInsertionMode.StartOfPhase,
+        (context, next) => next(context));
+
+Examples
+========
+
+The middleware API is general enough that it's not obvious when you'd reach for it. These are the shapes that come up most often.
+
+Timing a Resolve
+----------------
+
+Wrapping the activation phase measures how long it takes to construct a component. ``NewInstanceActivated`` distinguishes a real activation from a shared instance being handed back, so you don't record timings for work that never happened.
+
+.. code-block:: csharp
+
+    builder.RegisterType<ExpensiveComponent>().ConfigurePipeline(p =>
+    {
+        p.Use(PipelinePhase.Activation, MiddlewareInsertionMode.StartOfPhase, (context, next) =>
+        {
+            var stopwatch = Stopwatch.StartNew();
+            next(context);
+            stopwatch.Stop();
+
+            if (context.NewInstanceActivated)
+            {
+                Console.WriteLine("Activated {0} in {1}ms", context.Service, stopwatch.ElapsedMilliseconds);
+            }
+        });
+    });
+
+Substituting Parameters
+-----------------------
+
+``ParameterSelection`` runs just before activation, which makes it the place to change what gets passed to the constructor. Use ``ChangeParameters`` rather than assigning to ``Parameters``, and append to the existing set so an explicitly-passed parameter still wins.
+
+.. code-block:: csharp
+
+    builder.RegisterType<ReportGenerator>().ConfigurePipeline(p =>
+    {
+        p.Use(PipelinePhase.ParameterSelection, (context, next) =>
+        {
+            var extra = new TypedParameter(typeof(IClock), new SystemClock());
+            context.ChangeParameters(context.Parameters.Concat(new[] { extra }));
+
+            next(context);
+        });
+    });
+
+Short-Circuiting a Resolve
+--------------------------
+
+Setting ``Instance`` and *not* calling ``next`` ends the pipeline and returns your object. This is how you supply an instance from somewhere Autofac doesn't know about - an external cache, for example.
+
+.. code-block:: csharp
+
+    builder.RegisterServiceMiddleware<IPricingTable>(PipelinePhase.Sharing, (context, next) =>
+    {
+        if (cache.TryGet(out IPricingTable cached))
+        {
+            // Skip activation entirely; nothing further in the pipeline runs.
+            context.Instance = cached;
+            return;
+        }
+
+        next(context);
+        cache.Store((IPricingTable)context.Instance);
+    });
+
+Bear in mind that an instance you supply this way was not activated by Autofac, so it isn't tracked for disposal and the :doc:`lifetime events <../lifetime/events>` don't fire for it. If the cached object needs cleaning up, that's yours to arrange.
+
+Applying Behavior Across Many Services
+--------------------------------------
+
+Service middleware plus the ``Type`` overloads cover the "apply this to everything" case that would otherwise mean an extension method on every single registration. Because it attaches to the *service*, it runs no matter which registration ends up satisfying the request - including through :doc:`decorators <adapters-decorators>`, where a registration-level hook would only see the innermost component.
+
+.. code-block:: csharp
+
+    var auditableServices = typeof(Program).Assembly
+        .GetTypes()
+        .Where(t => t.IsInterface && t.IsDefined(typeof(AuditedAttribute), false));
+
+    foreach (var serviceType in auditableServices)
+    {
+        builder.RegisterServiceMiddleware(serviceType, "audit", PipelinePhase.ResolveRequestStart, (context, next) =>
+        {
+            next(context);
+            auditLog.Record(context.Service, context.Instance);
+        });
+    }
+
 Service Middleware Sources
 ==========================
 


### PR DESCRIPTION
Fixes #160.

## Why

The pipeline page explains the API thoroughly, but its only example was a "Hello World" that writes to the console. That leaves a reader knowing *how* to add middleware and not *what to add it for* — which is exactly what #160 asked for.

#160 also pointed at autofac/Autofac#1337 as a case solved with middleware where the solution "wasn't an obvious solution". Following that thread, the ask was an aspect applied to every registration without calling an extension method on each one — and that's the scenario that motivated the `RegisterServiceMiddleware` overloads added in 8.2.0. Those overloads turned out to be undocumented too, so this covers both.

## What's added

Four examples, each a shape that comes up in practice rather than a demo:

- **Timing a resolve** — wraps the activation phase. Uses `NewInstanceActivated` to avoid recording timings when a shared instance was handed back and nothing was actually constructed.
- **Substituting parameters** — `ParameterSelection` is documented in the phase table as "the recommended point at which the resolve parameters should be replaced" but had no example. Shows `ChangeParameters` and appends to the existing set so an explicitly-passed parameter still wins.
- **Short-circuiting a resolve** — set `Instance`, don't call `next`. The phase table says to use `Sharing` "to choose your own shared instance"; this is what that looks like.
- **Applying behavior across many services** — the #1337 case. Notes that because service middleware attaches to the *service*, it runs whichever registration satisfies the request, including through decorators, where a registration-level hook would only see the innermost component.

Plus the three undocumented pieces of the 8.2.0 API: the `Type`-based overloads for when the service type isn't known at compile time, the `descriptor` that names your middleware in [resolve traces](https://autofac.readthedocs.io/en/latest/troubleshooting/tracing.html) instead of leaving it `anonymous`, and `MiddlewareInsertionMode.StartOfPhase`.

## The sharp edge, called out

The short-circuit example carries a warning, because the trap isn't visible from the API. `DisposalTrackingMiddleware` runs in the **registration** pipeline (`Phase => PipelinePhase.Activation`, added to `ComponentRegistration._lateBuildPipeline`). An instance supplied from the **service** pipeline's `Sharing` phase never reaches it, so it isn't tracked for disposal and its lifetime events never fire. Easy to ship a leak on.

## Verification

Every API in the new examples was checked against source rather than assumed:

- All four `IResolvePipelineBuilder.Use` overloads confirmed in `PipelineBuilderExtensions.cs`, including the `(phase, insertionMode, callback)` form the timing example uses.
- `ChangeParameters`, `Instance`, `NewInstanceActivated`, `Service` confirmed on `ResolveRequestContext`.
- All nine `RegisterServiceMiddleware` overloads confirmed in `ServiceMiddlewareRegistrationExtensions.cs`; the `Type` and `descriptor` forms are exercised by `RegistrationOnlyIfTests`.
- Each example pairs a service phase with service middleware and a registration phase with `ConfigurePipeline`, since the docs note that crossing them is an error.

`sphinx -b html -W --keep-going` and `doc8` clean. I also checked the rendered heading tree: the four examples nest correctly as `h3` under a new `Examples` `h2`, which confirms the hierarchy repair from #197 is holding.
