### PR TITLE
Restructure metadata views and fix references to a removed API

### DIFF
--- a/docs/advanced/metadata.rst
+++ b/docs/advanced/metadata.rst
@@ -62,12 +62,50 @@ Other components can consume metadata using the ``Meta<T>`` type.
       }
     }
 
-To consume metadata without creating the target component, use ``Meta<Lazy<T>>`` or the .NET 4 ``Lazy<T, TMetadata>`` types as shown below.
+To consume metadata without creating the target component, use ``Meta<Lazy<T>>``, which exposes the same dictionary alongside a ``Lazy<T>``.
 
-Strongly-Typed Metadata
-=======================
+Metadata Views
+==============
 
-To avoid the use of string-based keys for describing metadata, a metadata class can be defined with a public read/write property for every metadata item:
+Indexing a dictionary by string key works, but it isn't checked at compile time and a typo surfaces at runtime. ``Meta<T, TMetadata>`` and ``Lazy<T, TMetadata>`` take a second type argument - a **metadata view** - that projects the dictionary onto a type of your choosing.
+
+Only three shapes can serve as a view:
+
+- ``IDictionary<string, object>``, which hands back the dictionary unchanged.
+- A concrete **class** with either a parameterless constructor or a constructor taking ``IDictionary<string, object>``.
+- An **interface**, which requires the :doc:`Autofac.Mef <../integration/mef>` package.
+
+Registration and consumption are independent, so metadata registered with string keys can be consumed through a typed view and vice versa.
+
+Dictionary Views
+----------------
+
+Naming ``IDictionary<string, object>`` as the view hands you the raw dictionary. There's no type to define and no extra package needed, so this is the escape hatch when a view type would be ceremony for its own sake:
+
+.. sourcecode:: csharp
+
+    public class Log
+    {
+      readonly IEnumerable<Lazy<ILogAppender, IDictionary<string, object>>> _appenders;
+
+      public Log(IEnumerable<Lazy<ILogAppender, IDictionary<string, object>>> appenders)
+      {
+        _appenders = appenders;
+      }
+
+      public void Write(string destination, string message)
+      {
+        var appender = _appenders.First(a => a.Metadata["AppenderName"].Equals(destination));
+        appender.Value.Write(message);
+      }
+    }
+
+You give up compile-time checking of the keys, which is the whole reason the other two shapes exist.
+
+Class Views
+-----------
+
+A metadata class declares a public read/write property for every metadata item:
 
 .. sourcecode:: csharp
 
@@ -76,7 +114,7 @@ To avoid the use of string-based keys for describing metadata, a metadata class 
       public string AppenderName { get; set; }
     }
 
-At registration time, the class is used with the overloaded ``WithMetadata`` method to associate values:
+At registration time, the class is used with the overloaded ``WithMetadata`` method to associate values. Notice the strongly-typed ``AppenderName`` property:
 
 .. sourcecode:: csharp
 
@@ -85,29 +123,15 @@ At registration time, the class is used with the overloaded ``WithMetadata`` met
         .WithMetadata<AppenderMetadata>(m =>
             m.For(am => am.AppenderName, "screen"));
 
-Notice the use of the strongly-typed ``AppenderName`` property.
-
-Registration and consumption of metadata are separate, so strongly-typed metadata can be consumed via the weakly-typed techniques and vice-versa.
-
-You can also provide default values using the ``DefaultValue`` attribute:
-
-.. sourcecode:: csharp
-
-    public class AppenderMetadata
-    {
-      [DefaultValue("screen")]
-      public string AppenderName { get; set; }
-    }
-
-If you are able to reference ``System.ComponentModel.Composition`` you can use the ``System.Lazy<T, TMetadata>`` type for consuming values from the strongly-typed metadata class:
+Consume it by naming the class as the view:
 
 .. sourcecode:: csharp
 
     public class Log
     {
-      readonly IEnumerable<Lazy<ILogAppender, LogAppenderMetadata>> _appenders;
+      readonly IEnumerable<Lazy<ILogAppender, AppenderMetadata>> _appenders;
 
-      public Log(IEnumerable<Lazy<ILogAppender, LogAppenderMetadata>> appenders)
+      public Log(IEnumerable<Lazy<ILogAppender, AppenderMetadata>> appenders)
       {
         _appenders = appenders;
       }
@@ -119,7 +143,17 @@ If you are able to reference ``System.ComponentModel.Composition`` you can use t
       }
     }
 
-Another neat trick is the ability to pass the metadata dictionary into the constructor of your metadata class:
+Autofac fills the properties by matching each metadata key to a property name, so **every property needs a value**. Supply a fallback with the ``DefaultValue`` attribute for any that might be absent:
+
+.. sourcecode:: csharp
+
+    public class AppenderMetadata
+    {
+      [DefaultValue("screen")]
+      public string AppenderName { get; set; }
+    }
+
+Alternatively, give the class a constructor taking the metadata dictionary and do the mapping yourself. Autofac prefers this constructor over a parameterless one when both are present, and it does no property population at all in that case:
 
 .. sourcecode:: csharp
 
@@ -133,12 +167,10 @@ Another neat trick is the ability to pass the metadata dictionary into the const
       public string AppenderName { get; set; }
     }
 
-Interface-Based Metadata
-========================
+Interface Views
+---------------
 
-If you have access to ``System.ComponentModel.Composition`` and include a reference to the :doc:`Autofac.Mef <../integration/mef>` package you can use an interface for your metadata instead of a class.
-
-The interface should be defined with a readable property for every metadata item:
+An interface view is the least ceremony to declare - readable properties only, no setters and no constructor:
 
 .. sourcecode:: csharp
 
@@ -147,13 +179,13 @@ The interface should be defined with a readable property for every metadata item
       string AppenderName { get; }
     }
 
-You must also call the ``RegisterMetadataRegistrationSources`` method on the ``ContainerBuilder`` before registering the metadata against the interface type.
+**Interfaces are not handled by core Autofac.** They come from the MEF metadata registration sources, so you need a reference to the :doc:`Autofac.Mef <../integration/mef>` package and a call to ``RegisterMetadataRegistrationSources()`` before registering metadata against the interface:
 
 .. sourcecode:: csharp
 
     builder.RegisterMetadataRegistrationSources();
 
-At registration time, the interface is used with the overloaded ``WithMetadata`` method to associate values:
+At registration time the interface is used with the same overloaded ``WithMetadata`` method:
 
 .. sourcecode:: csharp
 
@@ -162,7 +194,26 @@ At registration time, the interface is used with the overloaded ``WithMetadata``
         .WithMetadata<IAppenderMetadata>(m =>
             m.For(am => am.AppenderName, "screen"));
 
-Resolving the value can be done in the same manner as for class based metadata.
+Consumption is identical to a class view - name the interface as the second type argument.
+
+When a View Can't Be Used
+-------------------------
+
+If the view type is none of the three supported shapes, resolution fails with::
+
+    The type 'IAppenderMetadata' cannot be used as a metadata view.
+    A metadata view must be a concrete class with a parameterless or
+    dictionary constructor.
+
+**That message names the view type, but the usual cause is a missing** ``RegisterMetadataRegistrationSources()`` **call.** An interface view without the MEF sources falls through to the core provider, which only accepts classes, so it reports your interface as the problem.
+
+A class with neither a parameterless nor a dictionary constructor produces the identical message - which is why adding a parameterless constructor can look like it fixed an interface-shaped problem when it hasn't.
+
+The other failure comes from a class view missing a value::
+
+    Export metadata for 'AppenderName' is missing and no default value was supplied.
+
+That means a property had no matching metadata key and no ``DefaultValue`` attribute to fall back on.
 
 Attribute-Based Metadata
 ========================
@@ -289,7 +340,7 @@ That component will require you to register a service with the specified metadat
     builder.RegisterModule<AttributedMetadataModule>();
     builder.RegisterType<CenturyArtwork>().As<IArtwork>();
 
-    // Specify WithAttributeFilter for the consumer
+    // Specify WithAttributeFiltering for the consumer
     builder.RegisterType<ArtDisplay>().As<IDisplay>().WithAttributeFiltering();
 
     // ...
@@ -316,13 +367,28 @@ The metadata attributes you create aren't just used by default. In order to tell
     // ...
     var container = builder.Build();
 
-If you're using metadata filters (``KeyFilterAttribute`` or ``WithAttributeFiltering`` in your constructors), you need to register those components using the ``WithAttributeFiltering`` extension. Note that if you're *only* using filters but not attributed metadata, you don't actually need the ``AttributedMetadataModule``. Metadata filters stand on their own.
+If you're using metadata filters (``KeyFilterAttribute`` or ``MetadataFilterAttribute`` in your constructors), you need to register those components using the ``WithAttributeFiltering`` extension. Note that if you're *only* using filters but not attributed metadata, you don't actually need the ``AttributedMetadataModule``. Metadata filters stand on their own.
 
 .. sourcecode:: csharp
 
     var builder = new ContainerBuilder();
 
-    // Specify WithAttributeFilter for the consumer
+    // Specify WithAttributeFiltering for the consumer
     builder.RegisterType<ArtDisplay>().As<IDisplay>().WithAttributeFiltering();
     // ...
     var container = builder.Build();
+
+Opting In Per Registration
+--------------------------
+
+``AttributedMetadataModule`` reads metadata attributes for everything in the container. If you'd rather opt in one registration at a time, ``WithAttributedMetadata()`` does the same job for a single reflection-based registration - so ``RegisterType`` and ``RegisterAssemblyTypes`` opt in the same way:
+
+.. sourcecode:: csharp
+
+    builder.RegisterType<CenturyArtwork>().As<IArtwork>().WithAttributedMetadata();
+
+    builder.RegisterAssemblyTypes(typeof(CenturyArtwork).Assembly)
+           .As<IArtwork>()
+           .WithAttributedMetadata();
+
+This works on reflection-based registrations, where the implementation type is known when the registration is made. Delegate registrations don't expose one, so those still need the module. Mixing the two is safe - the module doesn't overwrite metadata keys that are already present, so metadata is applied once either way.

--- a/docs/faq/select-by-context.rst
+++ b/docs/faq/select-by-context.rst
@@ -453,7 +453,7 @@ For your consuming components, you can also use attributed metadata if you don't
       public CustomerNotifier([WithMetadata("SendAllowed", "notification")] ISender notificationStrategy) { ... }
     }
 
-If your consuming components use the attribute, you need to register them ``WithAttributeFilter``:
+If your consuming components use the attribute, you need to register them ``WithAttributeFiltering``:
 
 .. sourcecode:: csharp
 
@@ -461,8 +461,8 @@ If your consuming components use the attribute, you need to register them ``With
     {
       protected override void Load(ContainerBuilder builder)
       {
-        builder.RegisterType<ShippingProcessor>().WithAttributeFilter();
-        builder.RegisterType<CustomerNotifier>().WithAttributeFilter();
+        builder.RegisterType<ShippingProcessor>().WithAttributeFiltering();
+        builder.RegisterType<CustomerNotifier>().WithAttributeFiltering();
       }
     }
 


### PR DESCRIPTION
Fixes #144.

## Why

#144 asked for "additional guidance for custom metadata usage," and the diagnosis in that thread was that the page had the facts but not the rule: class metadata, interface metadata, dictionary constructors and `DefaultValue` were each documented in a separate section, with nothing saying which mechanism handles which. As the issue put it, "trying to pick up various bits from each section and put them all together is a challenge."

The reporter's actual problem is the tell. They used a **class** where the example used an **interface**, got an exception naming their type as an invalid metadata view, and adding a parameterless constructor appeared to fix it in a test but not in practice — because the two situations produce the *same* error message.

## What changed structurally

One distinction decides the shape of this: **`Meta<T>` is not a metadata view.** It goes through `MetaRegistrationSource` and exposes `IDictionary<string, object?>` directly — the view provider never runs. A view is specifically the `TMetadata` argument of `Meta<T, TMetadata>` / `Lazy<T, TMetadata>`, which route through `MetadataViewProvider` (via `StronglyTypedMetaRegistrationSource` and `LazyWithMetadataRegistrationSource`).

So untyped access and typed views are two mechanisms, not three variants of one, and the page is split along that line:

```text
Adding Metadata to a Component Registration      (unchanged)
Consuming Metadata                               Meta<T> and its dictionary
Metadata Views                                   the three shapes, at a glance
  Dictionary Views
  Class Views                                    absorbs Strongly-Typed Metadata
  Interface Views                                absorbs Interface-Based Metadata
  When a View Can't Be Used
Attribute-Based Metadata                         (unchanged)
```

Each view subsection carries registration *and* consumption, since they differ per shape. The old `Strongly-Typed Metadata` and `Interface-Based Metadata` sections are absorbed rather than restated — my first attempt added a requirements section alongside them, which duplicated both.

New within that:

- **Dictionary views had no example at all.** There's one now, with the tradeoff stated: you lose compile-time checking of keys, which is the reason the other two shapes exist.
- **Class views** now say every property needs a value or a `DefaultValue`, and that a dictionary constructor wins over a parameterless one and suppresses property population entirely.
- **Interface views** lead with the fact that core Autofac doesn't handle them.
- **When a View Can't Be Used** quotes both failure messages verbatim so a search lands here, and explains the trap: the error names the view type, but the usual cause is a missing `RegisterMetadataRegistrationSources()` call — and a class without a suitable constructor produces the identical message.

The heading term is "view" deliberately. The error message says "cannot be used as a metadata view," so that's the word a stuck reader will search for.

### Anchors

This drops the `#strongly-typed-metadata` and `#interface-based-metadata` anchors. I checked the workspace and searched the whole `autofac` org through the code search API — nothing links to either.

## A compile break, fixed

`faq/select-by-context.rst` told readers to register components `WithAttributeFilter()`. That method was **removed** in Autofac.Extras.AttributeMetadata 7.0.0 in favor of core's `WithAttributeFiltering()`, so the sample doesn't compile against current packages. Fixed there, plus two code comments in `metadata.rst` that still named it while the surrounding code already used the new one.

One sentence also listed `WithAttributeFiltering` as something you put "in your constructors" — that's `MetadataFilterAttribute`; `WithAttributeFiltering` is the registration call.

## Also

`WithAttributedMetadata()` on individual registrations, new in 7.0.0, so `RegisterType` and `RegisterAssemblyTypes` can opt in the same way. It needs a reflection-based registration — delegate registrations have no implementation type at registration time, so those still need the module — and mixing the two is safe, since the module doesn't overwrite keys already present.

Dropped the ".NET 4" qualifier from `Lazy<T, TMetadata>`, which I'd deliberately left alone in #197 to keep that PR free of content changes. Also renamed the stray `LogAppenderMetadata` in the `Lazy` consumption example to `AppenderMetadata`, the class the surrounding text actually defines.

## Verification

The rules and both messages were read out of `MetadataViewProvider.cs` and `MetadataViewProviderResources.resx` rather than inferred — including that the class check is `!typeof(TMetadata).IsClass`, that the dictionary constructor is preferred over the parameterless one, and that `GetMetadataValue` throws when a key is absent with no `DefaultValueAttribute`. The interface path was confirmed in `Autofac.Mef`'s `StronglyTypedMetadataRegistrationSource`, which calls `AttributedModelServices.GetMetadataView`. `WithAttributedMetadata()`'s constraints come from its XML remarks.

Confirmed every pre-existing example survived the restructure by grepping for each one, and checked the rendered heading tree and section anchors.

`sphinx -b html -W --keep-going`, `doc8` and `npm run lint` are clean. `doc8` caught my first attempt at `sourcecode:: none`, which has no Pygments lexer; the exception blocks use a plain `::` literal block, matching how the troubleshooting pages already present exception text.
