### PR TITLE
Link example projects from their documentation pages

### DIFF
--- a/docs/advanced/interceptors.rst
+++ b/docs/advanced/interceptors.rst
@@ -241,3 +241,8 @@ Straddling a major version is what breaks. ``Autofac.Extras.DynamicProxy`` 8.x d
 ``System.IO.FileLoadException: Could not load file or assembly 'Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc'. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)``
 
 On .NET Framework a binding redirect to ``5.0.0.0`` may get you past it, but Castle 5 removed API that Castle 4 exposed, so a redirect only holds if the library on the older version doesn't reach for anything that went away. Modern .NET has no binding redirects, so there the only real fix is getting every direct and transitive dependency onto Castle.Core 5.x - which sometimes means filing issues with projects still on 4.x. `The Castle.Core issue discussing this versioning policy has the background. <https://github.com/castleproject/Core/issues/288>`_
+
+Example
+=======
+
+There is an example project showing interception wired up both on the registration and with an attribute `in the Autofac examples repository <https://github.com/autofac/Examples/tree/main/src/DynamicProxyExample>`_.

--- a/docs/advanced/metadata.rst
+++ b/docs/advanced/metadata.rst
@@ -392,3 +392,8 @@ Opting In Per Registration
            .WithAttributedMetadata();
 
 This works on reflection-based registrations, where the implementation type is known when the registration is made. Delegate registrations don't expose one, so those still need the module. Mixing the two is safe - the module doesn't overwrite metadata keys that are already present, so metadata is applied once either way.
+
+Example
+=======
+
+There is an example project showing all four ways to attach metadata, and filtering on it at the point of injection, `in the Autofac examples repository <https://github.com/autofac/Examples/tree/main/src/AttributeMetadataExample>`_.

--- a/docs/advanced/multitenant.rst
+++ b/docs/advanced/multitenant.rst
@@ -654,3 +654,5 @@ Example
 The Autofac example repository has a `multitenant WCF service <https://github.com/autofac/Examples/tree/main/src/MultitenantExample.WcfService>`_ and `associated client MVC application <https://github.com/autofac/Examples/tree/main/src/MultitenantExample.MvcApplication>`_ to illustrate how :doc:`multitenant service hosting <../advanced/multitenant>` works.
 
 There is also a `very simple console application <https://github.com/autofac/Examples/tree/main/src/MultitenantExample.ConsoleApplication>`_ example.
+
+For the ASP.NET Core side there is `a multitenant web application <https://github.com/autofac/Examples/tree/main/src/MultitenantExample.AspNetCore>`_ that identifies the tenant from the query string and shows an unconfigured tenant falling back to the container-wide default.

--- a/docs/advanced/pipelines.rst
+++ b/docs/advanced/pipelines.rst
@@ -306,6 +306,8 @@ Service middleware plus the ``Type`` overloads cover the "apply this to everythi
         });
     }
 
+All of the shapes above are collected in `a runnable example project <https://github.com/autofac/Examples/tree/main/src/MiddlewarePipelineExample>`_, including one that only works on the registration pipeline: middleware that substitutes parameters has to be added with ``ConfigurePipeline``, because ``ParameterSelection`` is not a phase a service pipeline accepts.
+
 Service Middleware Sources
 ==========================
 

--- a/docs/advanced/pooled-instances.rst
+++ b/docs/advanced/pooled-instances.rst
@@ -249,3 +249,8 @@ Handing over storage moves some responsibilities with it, and these are easy to 
 - If the pool implements ``IDisposable``, the container disposes it at shutdown.
 
 Unless you need one of those knobs, a :ref:`pool policy <pooled-instances-policies>` is the simpler place to customize behavior.
+
+Example
+=======
+
+There is an example project showing instance reuse across lifetime scopes and a reset-on-return policy `in the Autofac examples repository <https://github.com/autofac/Examples/tree/main/src/PoolingExample>`_.

--- a/docs/configuration/xml.rst
+++ b/docs/configuration/xml.rst
@@ -362,3 +362,8 @@ Multiple Files or Sections
 --------------------------
 
 You can use multiple settings readers in the same container, to read different sections or even different config files if the filename is supplied to the ``ConfigurationSettingsReader`` constructor.
+
+Example
+=======
+
+There is an example project showing configuration-driven registration, including loading a plugin assembly the application holds no reference to, `in the Autofac examples repository <https://github.com/autofac/Examples/tree/main/src/ConfigurationExample>`_.

--- a/docs/integration/netcore.rst
+++ b/docs/integration/netcore.rst
@@ -107,3 +107,8 @@ In a complex application you may want to keep services registered using ``Popula
         }
       }
     }
+
+Example
+=======
+
+There is an example project showing Autofac under the generic host `in the Autofac examples repository <https://github.com/autofac/Examples/tree/main/src/GenericHostBuilderExample>`_.

--- a/docs/troubleshooting/tracing.rst
+++ b/docs/troubleshooting/tracing.rst
@@ -354,3 +354,8 @@ When you get this low, you can control the subscriptions for your events separat
     // the tracer should get an event.
     var tracer = new ConsoleOperationTracer();
     container.DiagnosticSource.Subscribe(tracer, e => e == "Autofac.Operation.Start");
+
+Example
+=======
+
+There is an example project showing the DOT graph tracer, including how to render the captured graph, `in the Autofac examples repository <https://github.com/autofac/Examples/tree/main/src/DotGraphExample>`_.


### PR DESCRIPTION
Part of the Examples modernization tracked in autofac/Examples#32.

## Proposed Changes

**Every example is now reachable from the page that documents it.** That was already true in the other direction — each example README links to its documentation page — but eight examples had no inbound link.

New `Example` sections on the interceptors, pooled instances, tracing, .NET Core, JSON/XML configuration, and metadata pages. The multitenant page gains the ASP.NET Core sample. The resolve pipeline examples now point at the runnable project, calling out the one case that does not work the obvious way: middleware substituting parameters has to be added with `ConfigurePipeline`, because `ParameterSelection` is not a phase a service pipeline accepts.

That leaves only `ConfigurationExampleInterface` and `ConfigurationExamplePlugin` unlinked, which is correct — they are supporting libraries for `ConfigurationExample`, not examples in their own right.

## Verification

`pre-commit` passes, including `doc8` and markdownlint. All links into the Examples repository resolve to a directory that exists and use `/tree/main`, checked against a local clone rather than by eye. Section underlines are at least as long as their titles in every changed file.

## Note

An earlier revision of this branch also contained the `docs/integration/aspnetcore.rst` and `docs/resolve/relationships.rst` changes that belong to #204. That was my mistake — I picked them up out of a shared working tree and committed them here. The branch has been rewritten to drop them, so this PR is now only the eight files above and does not overlap #204.
