### PR TITLE
Correct package guidance and document 8.0.0 behavior for classic integrations

### DIFF
--- a/docs/integration/signalr.rst
+++ b/docs/integration/signalr.rst
@@ -2,11 +2,11 @@
 SignalR
 =======
 
-SignalR integration requires the `Autofac.SignalR NuGet package <https://nuget.org/packages/Autofac.SignalR/>`_.
+SignalR integration requires the `Autofac.SignalR2 NuGet package <https://www.nuget.org/packages/Autofac.SignalR2/>`_.
 
 SignalR integration provides dependency injection integration for SignalR hubs. **Due to SignalR internals, there is no support in SignalR for per-request lifetime dependencies.**
 
-Along with this documentation that's Autofac specific, you may also be interested in the `Microsoft documentation on SignalR and dependency injection. <http://www.asp.net/signalr/overview/advanced/dependency-injection>`_
+Along with this documentation that's Autofac specific, you may also be interested in the `Microsoft documentation on SignalR and dependency injection. <https://learn.microsoft.com/en-us/aspnet/signalr/overview/advanced/dependency-injection>`_
 
 .. contents::
   :local:
@@ -151,4 +151,4 @@ If you are using SignalR :doc:`as part of an OWIN application <owin>`, you need 
       }
     }
 
-A common error in OWIN integration is use of the ``GlobalHost``. **In OWIN you create the configuration from scratch.** You should not reference ``GlobalHost`` anywhere when using the OWIN integration. `Microsoft has documentation about this and other IoC integration concerns here. <http://www.asp.net/signalr/overview/advanced/dependency-injection>`_
+A common error in OWIN integration is use of the ``GlobalHost``. **In OWIN you create the configuration from scratch.** You should not reference ``GlobalHost`` anywhere when using the OWIN integration. `Microsoft has documentation about this and other IoC integration concerns here. <https://learn.microsoft.com/en-us/aspnet/signalr/overview/advanced/dependency-injection>`_

--- a/docs/integration/wcf.rst
+++ b/docs/integration/wcf.rst
@@ -335,9 +335,7 @@ It is possible to manually perform constructor injection for service marked with
 Singletons With Interception
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Hosting a singleton that also uses :doc:`interception <../advanced/interceptors>` works, and it's worth knowing why it needs help. WCF refuses to host a class that both *declares* and *inherits* ``ServiceContractAttribute``. Castle's dynamic proxy copies type-level attributes from the proxied interface onto the generated class, so an intercepted singleton is exactly that shape - and host construction used to fail.
-
-``AutofacServiceHostFactory`` now wraps such an instance in a ``DispatchProxy`` that implements the contract and forwards every call. A ``DispatchProxy`` type only inherits the contract through the interface it implements, never declaring it on the class, so WCF accepts it while calls - and therefore the interceptors - still run against the resolved instance.
+Combining ``SingleInstance()`` with :doc:`interception <../advanced/interceptors>` needs nothing extra from you. Register the service the way you normally would and hosting works:
 
 .. sourcecode:: csharp
 
@@ -347,7 +345,11 @@ Hosting a singleton that also uses :doc:`interception <../advanced/interceptors>
            .InterceptedBy(typeof(CallLogger))
            .SingleInstance();
 
-Wrapping only happens when it's needed. A service class carries its contract on the interface rather than on itself, so an ordinary singleton is handed to WCF directly with no proxy in between.
+It didn't always. WCF refuses to host a class that both *declares* and *inherits* ``ServiceContractAttribute``, and a dynamic proxy is exactly that shape, because Castle copies type-level attributes from the proxied interface onto the generated class. ``AutofacServiceHostFactory`` now hands WCF a ``DispatchProxy`` that forwards every call to the resolved instance; it inherits the contract only through the interface it implements, so WCF accepts it and the interceptors still run.
+
+One consequence does reach your code. The type WCF hosts is that forwarding proxy rather than your service class, so a ``ServiceBehaviorAttribute`` applied to the class isn't seen. ``InstanceContextMode.Single`` is re-applied for you, because hosting a supplied instance requires it - but anything else you set on that attribute, ``ConcurrencyMode`` included, has to come from configuration or from the ``AutofacHostFactory.HostConfigurationAction`` hook, which runs against each host before it is returned.
+
+Wrapping only happens where it's needed. A plain service class carries its contract on the interface rather than on itself, so an ordinary singleton goes to WCF untouched.
 
 Simulating a Request Lifetime Scope
 -----------------------------------

--- a/docs/integration/wcf.rst
+++ b/docs/integration/wcf.rst
@@ -332,6 +332,23 @@ It is possible to manually perform constructor injection for service marked with
     // Pass it into the ServiceHost preventing it from creating an instance with the default constructor.
     var host = new ServiceHost(service, new Uri("http://localhost:8080/Service1"));
 
+Singletons With Interception
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Hosting a singleton that also uses :doc:`interception <../advanced/interceptors>` works, and it's worth knowing why it needs help. WCF refuses to host a class that both *declares* and *inherits* ``ServiceContractAttribute``. Castle's dynamic proxy copies type-level attributes from the proxied interface onto the generated class, so an intercepted singleton is exactly that shape - and host construction used to fail.
+
+``AutofacServiceHostFactory`` now wraps such an instance in a ``DispatchProxy`` that implements the contract and forwards every call. A ``DispatchProxy`` type only inherits the contract through the interface it implements, never declaring it on the class, so WCF accepts it while calls - and therefore the interceptors - still run against the resolved instance.
+
+.. sourcecode:: csharp
+
+    builder.RegisterType<Service1>()
+           .As<IService1>()
+           .EnableInterfaceInterceptors()
+           .InterceptedBy(typeof(CallLogger))
+           .SingleInstance();
+
+Wrapping only happens when it's needed. A service class carries its contract on the interface rather than on itself, so an ordinary singleton is handed to WCF directly with no proxy in between.
+
 Simulating a Request Lifetime Scope
 -----------------------------------
 

--- a/docs/integration/wcf.rst
+++ b/docs/integration/wcf.rst
@@ -320,6 +320,8 @@ IIS/WAS Hosted
 
 The ``AutofacServiceHostFactory`` identifies WCF services that are marked with ``InstanceContextMode.Single`` and will ensure that the ``ServiceHost`` can be provided with a singleton instance from the container. An exception will be thrown if the service in the container was not registered with the ``SingleInstance()`` lifetime scope. It is also invalid to register a ``SingleInstance()`` service in the container for a WCF service that is not marked as ``InstanceContextMode.Single``.
 
+If the singleton is also :doc:`intercepted <../advanced/interceptors>`, the factory hosts a forwarding proxy instead of your service class, so a ``ServiceBehaviorAttribute`` on the class is never read. ``InstanceContextMode.Single`` is re-applied for you; anything else set there - ``ConcurrencyMode`` in particular, given the recommendation above - has to come from configuration or from the ``AutofacHostFactory.HostConfigurationAction`` hook.
+
 Self-Hosted
 ~~~~~~~~~~~
 
@@ -331,25 +333,6 @@ It is possible to manually perform constructor injection for service marked with
     var service = container.Resolve<IService1>();
     // Pass it into the ServiceHost preventing it from creating an instance with the default constructor.
     var host = new ServiceHost(service, new Uri("http://localhost:8080/Service1"));
-
-Singletons With Interception
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Combining ``SingleInstance()`` with :doc:`interception <../advanced/interceptors>` needs nothing extra from you. Register the service the way you normally would and hosting works:
-
-.. sourcecode:: csharp
-
-    builder.RegisterType<Service1>()
-           .As<IService1>()
-           .EnableInterfaceInterceptors()
-           .InterceptedBy(typeof(CallLogger))
-           .SingleInstance();
-
-It didn't always. WCF refuses to host a class that both *declares* and *inherits* ``ServiceContractAttribute``, and a dynamic proxy is exactly that shape, because Castle copies type-level attributes from the proxied interface onto the generated class. ``AutofacServiceHostFactory`` now hands WCF a ``DispatchProxy`` that forwards every call to the resolved instance; it inherits the contract only through the interface it implements, so WCF accepts it and the interceptors still run.
-
-One consequence does reach your code. The type WCF hosts is that forwarding proxy rather than your service class, so a ``ServiceBehaviorAttribute`` applied to the class isn't seen. ``InstanceContextMode.Single`` is re-applied for you, because hosting a supplied instance requires it - but anything else you set on that attribute, ``ConcurrencyMode`` included, has to come from configuration or from the ``AutofacHostFactory.HostConfigurationAction`` hook, which runs against each host before it is returned.
-
-Wrapping only happens where it's needed. A plain service class carries its contract on the interface rather than on itself, so an ordinary singleton goes to WCF untouched.
 
 Simulating a Request Lifetime Scope
 -----------------------------------

--- a/docs/integration/webapi.rst
+++ b/docs/integration/webapi.rst
@@ -4,8 +4,6 @@ Web API
 
 Web API 2 integration requires the `Autofac.WebApi2 NuGet package <https://www.nuget.org/packages/Autofac.WebApi2>`_.
 
-Web API integration requires the `Autofac.WebApi NuGet package <https://www.nuget.org/packages/Autofac.WebApi/>`_.
-
 Web API integration provides dependency injection integration for controllers, model binders, and action filters. It also adds :doc:`per-request lifetime support <../faq/per-request-scope>`.
 
 **This page explains ASP.NET classic Web API integration.** If you are using ASP.NET Core, :doc:`see the ASP.NET Core integration page <aspnetcore>`.
@@ -201,7 +199,7 @@ For the filter to execute you need to register it with the container and inform 
 - AuthenticationFilter
 - AuthenticationFilterOverride
 - AuthorizationFilter
-- AuthorizationFilterOverrideW
+- AuthorizationFilterOverride
 - ExceptionFilter
 - ExceptionFilterOverride
 
@@ -293,8 +291,9 @@ In the same way as with standard Web API filters,  you are able to set the ``Htt
       return Task.FromResult(0);
     }
 
-    public void Task OnActionExecutedAsync(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken)
+    public Task OnActionExecutedAsync(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken)
     {
+      return Task.CompletedTask;
     }
   }
 
@@ -457,7 +456,7 @@ If you are using per-controller-type services, it is not possible to take depend
 Batching
 ========
 
-If you choose to use the `Web API batching functionality <https://blogs.msdn.microsoft.com/webdev/2013/11/01/introducing-batch-support-in-web-api-and-web-api-odata/>`_, be aware that the initial multipart request to the batch endpoint is where Web API creates the request lifetime scope. The child requests that are part of the batch all take place in-memory and will share that same request lifetime scope - you won't get a different scope for each child request in the batch.
+If you choose to use the `Web API batching functionality <https://learn.microsoft.com/en-us/aspnet/web-api/overview/releases/whats-new-in-aspnet-web-api-22#batch>`_, be aware that the initial multipart request to the batch endpoint is where Web API creates the request lifetime scope. The child requests that are part of the batch all take place in-memory and will share that same request lifetime scope - you won't get a different scope for each child request in the batch.
 
 This is due to the way the batch handling is designed within Web API and copies properties from the parent request to the child request. One of the properties that is intentionally copied by the ASP.NET Web API framework from parent to children is the request lifetime scope. There is no workaround for this and is outside the control of Autofac.
 

--- a/docs/integration/webforms.rst
+++ b/docs/integration/webforms.rst
@@ -270,6 +270,32 @@ Once this is in place, pages and controls will not have their dependencies injec
       // ...use the property later as needed.
     }
 
+Required Properties
+-------------------
+
+A page or control that declares C# ``required`` properties needs no attribute at all. The ``AttributedInjectionModule`` recognizes required members and injects **only** those properties:
+
+.. sourcecode:: csharp
+
+    // No [InjectProperties] needed - the required modifier is the opt-in.
+    public partial class MyPage : Page
+    {
+      public required IService MyService { get; set; }
+
+      // Not required, so not injected on this path.
+      public IOtherService Other { get; set; }
+    }
+
+Required properties declared on a base class count too, since Autofac walks the inheritance chain looking for them.
+
+The attributes still win where both are present. The module checks ``InjectPropertiesAttribute`` first, then ``InjectUnsetPropertiesAttribute``, and only falls back to required properties when neither is applied - so putting ``[InjectProperties]`` on a page with required properties injects *every* public settable property, not just the required ones.
+
+If you are injecting properties by hand rather than through the module, ``RequiredPropertySelector`` gives you the same filter:
+
+.. sourcecode:: csharp
+
+    cp.RequestLifetime.InjectProperties(objectToSet, new RequiredPropertySelector());
+
 Dependency Injection via Base Page Class
 ----------------------------------------
 


### PR DESCRIPTION
First of the classic ASP.NET work. Correctness fixes plus two undocumented behaviors.

## Two pages sent readers to abandoned packages

This is the part worth acting on. **Both wrong package names exist on NuGet**, which is exactly why the mistake survived — nothing 404s, you just quietly get decade-old code.

| Page said | Reality | Current package |
|---|---|---|
| `Autofac.SignalR` | last released **3.0.2**, for SignalR 1.x | `Autofac.SignalR2` **7.0.0** |
| `Autofac.WebApi` | last released **3.1.0**, for Web API 1 | `Autofac.WebApi2` **7.0.0** |

The Web API page was also self-contradictory: it opened with "Web API 2 integration requires the `Autofac.WebApi2` NuGet package" and then immediately said "Web API integration requires the `Autofac.WebApi` NuGet package." The duplicate sentence is gone.

Checked before changing: the repository link on the release notes page still reads `Autofac.SignalR`, and that one is **correct** — the repo and the package are named differently. Left alone.

## Other correctness fixes

- `AuthorizationFilterOverrideW` in the Web API filter type list — a typo.
- A filter example declared `public void Task OnActionExecutedAsync(...)`, which is not valid C#. Now returns `Task.CompletedTask`.
- The batching link moved off retired `blogs.msdn.microsoft.com`.

## Web Forms required properties (Autofac.Web 8.0.0)

A page or control with C# `required` properties needs no attribute — `AttributedInjectionModule` finds required members and injects **only** those, including ones inherited from a base class (it walks the chain).

The precedence is documented because it changes behavior in a surprising way: the module checks `InjectPropertiesAttribute`, then `InjectUnsetPropertiesAttribute`, and only *then* required members. So adding `[InjectProperties]` to a page that has required properties injects **every** public settable property rather than just the required ones. `RequiredPropertySelector` is noted for manual injection.

## WCF: one paragraph, not a section

I originally wrote a "Singletons With Interception" section for the 8.0.0 fix. Reviewed against "what can the reader act on," almost none of it survived:

- "needs nothing extra from you" — that's what the *absence* of a warning says for free
- the Castle/`DispatchProxy` history — implementation detail
- "wrapping only happens when needed" — reassurance

And `ContractForwardingProxy` is unreachable from consumer code: the class is public only because `DispatchProxy` requires a public base, while `WrapIfNecessary` and `Create` are both `internal`. So there is genuinely no action available anywhere in that material.

**What's left is one actionable fact.** Because the hosted type is the forwarding proxy rather than the service class, a class-level `ServiceBehaviorAttribute` is never read, and only `InstanceContextMode` is re-applied. That matters concretely: this page recommends `ConcurrencyMode.Multiple` for exactly these services a few paragraphs earlier, so following that advice with interception enabled would silently do nothing.

Two sentences, so it loses the heading and moves into **IIS/WAS Hosted** — which is both where the wrapping actually happens (self-hosting never goes through the host factory) and directly below the `ConcurrencyMode` recommendation it qualifies.

Net effect on `wcf.rst` is now **+2 lines** instead of a 17-line section.

## Verification

Package versions came from querying NuGet, not from memory. The Web Forms precedence is read off `AttributedInjection.cs` and `RequiredPropertySelector.cs`; the WCF rationale is the XML remarks on `ContractForwardingProxy` plus its `WrapIfNecessary` guard and the `AutofacHostFactory` call site.

`sphinx -b html -W --keep-going`, `doc8`, `pre-commit` and `npm run lint` clean. `-W` caught a section underline I left one character short.

Following the nested-inline-markup bug found on #204, I re-scanned every page for that class in both directions before pushing — zero instances — and read the **rendered** HTML for the lines I modified, not only the sections I added.

## Deferred

`owin.rst` still has the dead Katana and `owin.org` links. That page is being worked next for #180, so they land there.


