### PR TITLE
Document the MVC filter registration API

### DIFF
--- a/docs/integration/mvc.rst
+++ b/docs/integration/mvc.rst
@@ -172,7 +172,7 @@ When using the web forms view engine you set the ``Inherits`` attribute on the `
 Enable Property Injection for Action Filters
 ============================================
 
-To make use of property injection for your filter attributes call the ``RegisterFilterProvider()`` method on the ``ContainerBuilder`` before building your container and providing it to the ``AutofacDependencyResolver``.
+To make use of property injection for your filter attributes call the ``RegisterFilterProvider()`` method on the ``ContainerBuilder`` before building your container and providing it to the ``AutofacDependencyResolver``. The same call is what enables :ref:`registering a component as a filter <mvc-filters-via-di>`, so one is enough for both.
 
 .. sourcecode:: csharp
 
@@ -214,10 +214,96 @@ After applying the attributes to your actions as usual your work is done.
 .. sourcecode:: csharp
 
     [CustomActionFilter]
-    [CustomAuthorizeAttribute]
+    [CustomAuthorize]
     public ActionResult Index()
     {
+      return this.View();
     }
+
+.. _mvc-filters-via-di:
+
+Provide Filters via Dependency Injection
+========================================
+
+Property injection covers the case where you want to keep using filter attributes. The alternative is to skip attributes entirely and register an ordinary class as a filter, which lets the filter take its dependencies through its constructor and lets you decide at registration time which controllers and actions it applies to.
+
+Implement the Filter Interface
+------------------------------
+
+Write a class implementing the MVC filter interface you want - ``IActionFilter``, ``IAuthenticationFilter``, ``IAuthorizationFilter``, ``IExceptionFilter`` or ``IResultFilter`` from ``System.Web.Mvc``. These are the framework's own interfaces; unlike :doc:`Web API <webapi>`, MVC needs no Autofac-specific filter interface, because the MVC filter provider resolves a fresh filter per request rather than caching one instance.
+
+.. sourcecode:: csharp
+
+    public class LoggingActionFilter : IActionFilter
+    {
+      private readonly ILogger _logger;
+
+      public LoggingActionFilter(ILogger logger)
+      {
+        this._logger = logger;
+      }
+
+      public void OnActionExecuting(ActionExecutingContext filterContext)
+      {
+        this._logger.Write(filterContext.ActionDescriptor.ActionName);
+      }
+
+      public void OnActionExecuted(ActionExecutedContext filterContext)
+      {
+      }
+    }
+
+Register the Filter
+-------------------
+
+Register the class and say what it applies to. There is a method per filter type - ``AsActionFilterFor``, ``AsAuthenticationFilterFor``, ``AsAuthorizationFilterFor``, ``AsExceptionFilterFor`` and ``AsResultFilterFor`` - and each takes the controller as a type parameter. Autofac exposes the registration as the filter interface for you, so no ``As()`` call is needed.
+
+.. sourcecode:: csharp
+
+    // Every action on HomeController.
+    builder.RegisterType<LoggingActionFilter>()
+           .AsActionFilterFor<HomeController>()
+           .InstancePerRequest();
+
+Pass a lambda to target a single action instead of the whole controller. Use ``default`` for any parameters, since the expression only identifies the method:
+
+.. sourcecode:: csharp
+
+    builder.RegisterType<LoggingActionFilter>()
+           .AsActionFilterFor<HomeController>(c => c.Index(default(int)))
+           .InstancePerRequest();
+
+Naming a base controller applies the filter to everything deriving from it.
+
+Each method also takes an optional ``order``, defaulting to ``Filter.DefaultOrder``, which behaves the same way as the ``Order`` property on a filter attribute.
+
+One component can target several controllers or actions by chaining the calls:
+
+.. sourcecode:: csharp
+
+    builder.RegisterType<LoggingActionFilter>()
+           .AsActionFilterFor<HomeController>()
+           .AsActionFilterFor<AccountController>(c => c.Login(default(string)))
+           .InstancePerRequest();
+
+The targets aren't deduplicated, and the filter is applied once using the first entry that matches. If you register the same component against the same target twice with different ``order`` values, the first one wins.
+
+Filter Overrides
+----------------
+
+Alongside each registration method is an override form - ``AsActionFilterOverrideFor`` and so on - which registers the filter *and* marks it as an override. MVC then ignores filters of the same type coming from less specific scopes, where the scopes from least to most specific are global, controller, then action.
+
+.. sourcecode:: csharp
+
+    builder.RegisterType<LoggingActionFilter>()
+           .AsActionFilterOverrideFor<HomeController>(c => c.Index(default(int)))
+           .InstancePerRequest();
+
+If you only want to suppress the less specific filters without adding a replacement, the ``Override*For`` methods on ``ContainerBuilder`` add the marker on its own:
+
+.. sourcecode:: csharp
+
+    builder.OverrideActionFilterFor<HomeController>(c => c.Index(default(int)));
 
 Enable Injection of Action Parameters
 =====================================


### PR DESCRIPTION
The biggest remaining gap in the classic integration docs.

## Why

**Registering a component as an MVC filter was entirely undocumented**, while the identical capability on the Web API page gets a full section. Twenty public methods had nothing pointing at them:

- `AsActionFilterFor`, `AsAuthenticationFilterFor`, `AsAuthorizationFilterFor`, `AsExceptionFilterFor`, `AsResultFilterFor` — each with a controller-wide and an action-specific overload
- an `...OverrideFor` form of each
- five `Override*For` markers on `ContainerBuilder`

The MVC page only ever described `RegisterFilterProvider()` as the way to get *property injection into filter attributes*, which is a different feature.

## Consistency with the Web API page

The new section reuses that page's heading, **"Provide Filters via Dependency Injection."** The two pages describe the same capability, and disagreeing on what to call it is part of why one appeared not to have it.

## The framework difference is documented, because it changes what you write

MVC filters implement the framework's own `System.Web.Mvc` interfaces — `IActionFilter` and friends — **not** Autofac-specific ones. Verified why: `AutofacFilterProvider.GetFilters` resolves from `AutofacDependencyResolver.Current.RequestLifetimeScope` on every call, so MVC gets a fresh filter per request. Web API needs `IAutofacActionFilter` precisely because it caches a single instance instead. Someone moving between the two pages would otherwise reasonably assume MVC needs an Autofac interface too.

## Also covered

- The action-selector overload and its `default(T)` placeholders
- The `order` parameter, defaulting to `Filter.DefaultOrder`
- That naming a base controller covers everything deriving from it — confirmed via `metadata.ControllerType.IsAssignableFrom(...)`
- Chaining one component onto several targets, **with the consequence**: targets are not deduplicated and the first match wins, so registering the same component against the same target twice with different `order` values silently uses the first. That comes from the `FilterMetadataCollection` remarks, and it's the kind of thing you'd otherwise only discover by being confused.
- Filter overrides, both the "register and override" form and the marker-only form

## One correction to an existing section

`RegisterFilterProvider()` is also what makes these registrations work at all, not just property injection — the existing section now says so and links across.

I checked the obvious worry there: it *removes* the built-in `FilterAttributeFilterProvider`. Attribute filters are unaffected, because `AutofacFilterProvider` derives from it and calls `base.GetFilters`. Worth confirming rather than assuming, since the alternative would have been a silent regression for every `[Authorize]` in an application.

Also fixed the adjacent attribute example, where the action returned nothing and one attribute was written with a redundant `Attribute` suffix.

## Verification

Every method name and signature was extracted from `RegistrationExtensions.cs` rather than from release notes. Behavioral claims come from `AutofacFilterProvider` and the `FilterMetadataCollection` remarks.

`sphinx -b html -W --keep-going`, `doc8`, `pre-commit` and `npm run lint` clean. Nested-inline-markup scan run across all pages (zero), and I read the rendered HTML and heading tree for the new section.
