### PR TITLE
Document OWIN disposal and application shutdown

### DIFF
--- a/docs/integration/owin.rst
+++ b/docs/integration/owin.rst
@@ -2,9 +2,9 @@
 OWIN
 ====
 
-`OWIN (Open Web Interface for .NET) <http://owin.org/>`_ is a simpler model for composing web-based applications without tying the application to the web server. To do this, a concept of "middleware" is used to create a pipeline through which requests travel.
+OWIN (Open Web Interface for .NET) is a simpler model for composing web-based applications without tying the application to the web server. To do this, a concept of "middleware" is used to create a pipeline through which requests travel.
 
-Due to the differences in the way OWIN handles the application pipeline (detecting when a request starts/ends, etc.) integrating Autofac into an OWIN application is slightly different than the way it gets integrated into more "standard" ASP.NET apps. `You can read about OWIN and how it works on this overview. <http://www.asp.net/aspnet/overview/owin-and-katana/an-overview-of-project-katana>`_
+Due to the differences in the way OWIN handles the application pipeline (detecting when a request starts/ends, etc.) integrating Autofac into an OWIN application is slightly different than the way it gets integrated into more "standard" ASP.NET apps. `Microsoft's overview of Project Katana <https://learn.microsoft.com/en-us/aspnet/aspnet/overview/owin-and-katana/an-overview-of-project-katana>`_ covers how OWIN works.
 
 **The important thing to remember is that order of OWIN middleware registration matters.** Middleware gets processed in order of registration, like a chain, so you need to register foundational things (like Autofac middleware) first.
 
@@ -82,6 +82,38 @@ If you want more control over when DI-enabled middleware is added to the pipelin
     // AFTER the Web API middleware/handling.
     app.UseWebApi(config);
     app.UseMiddlewareFromContainer<MyCustomMiddleware>();
+
+Disposal and Application Shutdown
+=================================
+
+Two things get disposed in an OWIN application, and Autofac only handles one of them.
+
+**Request lifetime scopes are disposed for you** when Autofac creates them - that is, when you pass a container to ``UseAutofacMiddleware`` or ``UseAutofacLifetimeScopeInjector``. The scope is disposed as the request unwinds, whether or not the request succeeded.
+
+**Nothing disposes your container.** The package never registers for application shutdown on your behalf, so if you want the container disposed when the application stops, ask for it:
+
+.. sourcecode:: csharp
+
+    public class Startup
+    {
+      public void Configuration(IAppBuilder app)
+      {
+        var builder = new ContainerBuilder();
+        // Register dependencies, then...
+        var container = builder.Build();
+
+        app.UseAutofacMiddleware(container);
+
+        // Dispose the container when the host shuts down.
+        app.DisposeScopeOnAppDisposing(container);
+      }
+    }
+
+This hooks the OWIN ``host.OnAppDisposing`` token. **A host that doesn't supply that token makes the call do nothing** - there's no error, so don't treat it as a guarantee on every host. Self-hosted applications generally provide it.
+
+For a long-running server this matters less than it sounds, because the process is ending anyway. It matters when the host outlives the application, as when a self-host is started and stopped repeatedly in the same process or in tests, where an undisposed container leaks everything it was tracking.
+
+If you supply the request scope yourself using the ``UseAutofacLifetimeScopeInjector`` overload that takes a ``Func<IOwinContext, ILifetimeScope>``, **you own disposing that scope too.** Autofac only disposes scopes it created.
 
 Example
 =======


### PR DESCRIPTION
Fixes #180.

## Why

The OWIN page covered registering middleware and never said what gets cleaned up. Answering the question meant reading `AutofacAppBuilderExtensions.cs` — which is what the issue reporter was doing, and what a downstream Web API issue was confused by.

## Three facts, each of which changes what you write

**Request scopes are disposed by Autofac — but only the ones it created.** The injector passes `dispose: true` when you hand it a container, and `dispose: false` when you supply scopes through the `Func<IOwinContext, ILifetimeScope>` overload. In that second case **the scope is yours to dispose**, which the page never mentioned and which is not guessable from the method name.

**Nothing disposes your container.** `DisposeScopeOnAppDisposing` exists for this and is entirely opt-in — I grepped the package and no code path calls it. So a container is left undisposed unless the application asks.

Documented under its **real name**: `DisposeScopeOnAppDisposing`. The issue refers to `DisposeOnAppDisposing`, which doesn't exist.

**That call is not a guarantee.** It reads `host.OnAppDisposing` and only registers when the token `CanBeCanceled`:

```csharp
var token = context.Get<CancellationToken>("host.OnAppDisposing");
if (token.CanBeCanceled)
{
    token.Register(lifetimeScope.Dispose);
}
```

On a host that doesn't supply one it silently does nothing. Said plainly, because a reader who adds the call and assumes cleanup is happening would have no signal otherwise.

## Why it matters, stated honestly

I nearly left this as "call this method," but that fails the test of whether the reader can act on it. For a long-running server the process is ending anyway, so it barely matters. It matters when the **host outlives the application** — a self-host started and stopped repeatedly in the same process, or in tests — where an undisposed container leaks everything it was tracking. The section says that, so the reader can judge whether to care.

## Dead links

Two are gone, and they collapse into one live reference rather than being replaced one-for-one:

- `owin.org` no longer resolves. Its spec now lives in a **git submodule** of `owin/owin.github.io`, so there's no stable file to point at — I checked. The acronym expansion stands on its own, so that link is simply dropped.
- The `asp.net` Katana overview moved to `learn.microsoft.com`, and it explains what OWIN is, so it now carries both jobs.

**With these gone, the integration pages have no dead hosts left.** The remaining four (`code.google.com/p/slimtune`, and the three commercial-support sites) are in `best-practices` and `support`, which the meta-page work covers.

## Verification

Every claim read out of `AutofacAppBuilderExtensions.cs`: the `dispose: true`/`dispose: false` split between the two injector overloads, the `CanBeCanceled` guard, and the absence of any internal call to `DisposeScopeOnAppDisposing`.

`sphinx -b html -W --keep-going`, `doc8`, `pre-commit` and `npm run lint` clean; nested-markup scan clean; rendered HTML and heading tree checked.
