### PR TITLE
Rewrite Azure Functions for the isolated worker model

### DIFF
--- a/docs/integration/azurefunctions.rst
+++ b/docs/integration/azurefunctions.rst
@@ -2,183 +2,47 @@
 Azure Functions
 ===============
 
-Azure Functions supports dependency injection with the Microsoft dependency injection framework out of the box, but you can make it work with Autofac with a bit of bootstrapping code.
-
-We recommend reading the `official Microsoft documentation <https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection>`_ for an overview of dependency injection in the context of Azure Functions.
-
-.. contents::
-  :local:
-
-Overview of Steps
-=================
-
-#. Install Autofac, ``Autofac.Extensions.DependencyInjection``, and ``Microsoft.Azure.Functions.Extensions`` from NuGet.
-#. Add an Autofac-based job activator to create instances of your function classes.
-#. Create a ``Startup`` class where you register your components and replace the default job activator.
-
-Autofac Job Activator
-=====================
-
-A job activator is responsible for instantiating the classes that hold your functions. Add the following code to your project — it's a job activator that resolves the appropriate class from an Autofac lifetime scope. We'll implement ``LifetimeScopeWrapper`` and ``LoggerModule`` in the next steps.
+Azure Functions apps run on the .NET generic host, so there is nothing Functions-specific about wiring in Autofac. Attach the service provider factory to the host builder exactly as you would in any other generic host application.
 
 .. sourcecode:: csharp
 
-    internal class AutofacJobActivator : IJobActivatorEx
-    {
-        public T CreateInstance<T>()
+    var host = new HostBuilder()
+        .ConfigureFunctionsWorkerDefaults()
+        .UseServiceProviderFactory(new AutofacServiceProviderFactory())
+        .ConfigureContainer<ContainerBuilder>(builder =>
         {
-            // In practice, this method will not get called. We cannot safely resolve T here
-            // because we don't have access to an ILifetimeScope, so it's better to just
-            // throw.
-            throw new NotSupportedException();
-        }
+            builder.RegisterModule(new MyApplicationModule());
+        })
+        .Build();
 
-        public T CreateInstance<T>(IFunctionInstanceEx functionInstance)
-            where T : notnull
-        {
-            var lifetimeScope = functionInstance.InstanceServices
-                .GetRequiredService<LifetimeScopeWrapper>()
-                .Scope;
+    await host.RunAsync();
 
-            // This is necessary because some dependencies of ILoggerFactory are registered
-            // after FunctionsStartup.
-            var loggerFactory = functionInstance.InstanceServices.GetRequiredService<ILoggerFactory>();
-            lifetimeScope.Resolve<ILoggerFactory>(
-                new NamedParameter(LoggerModule.LoggerFactoryParam, loggerFactory)
-            );
-            lifetimeScope.Resolve<ILogger>(
-                new NamedParameter(LoggerModule.FunctionNameParam, functionInstance.FunctionDescriptor.LogName)
-            );
+Reference the ``Autofac.Extensions.DependencyInjection`` package alongside the Functions worker packages. ``ConfigureContainer`` runs after the service collection has been populated, so registrations there override anything the worker or other libraries added.
 
-            return lifetimeScope.Resolve<T>();
-        }
-    }
-
-Next, implement ``LifetimeScopeWrapper``. This class is resolved from the ``IServiceCollection`` and allows us to dispose the Autofac lifetime scope after the function has completed.
-
-.. sourcecode:: csharp
-
-  internal sealed class LifetimeScopeWrapper : IDisposable
-  {
-      public ILifetimeScope Scope { get; }
-
-      public LifetimeScopeWrapper(IContainer container)
-      {
-          Scope = container.BeginLifetimeScope();
-      }
-
-      public void Dispose()
-      {
-          Scope.Dispose();
-      }
-  }
-
-Special logic is needed for us to be able to resolve ``ILogger`` because certain logger factories are not initialized until after the ``Startup`` class has run. We can work around this by adding the following code.
-
-.. sourcecode:: csharp
-
-    internal class LoggerModule : Module
-    {
-        public const string LoggerFactoryParam = "loggerFactory";
-        public const string FunctionNameParam = "functionName";
-
-        protected override void Load(ContainerBuilder builder)
-        {
-            builder.Register((ctx, p) => p.Named<ILoggerFactory>(LoggerFactoryParam))
-                .SingleInstance();
-
-            builder.Register((ctx, p) =>
-                {
-                    var factory = ctx.Resolve<ILoggerFactory>();
-                    var functionName = p.Named<string>(FunctionNameParam);
-
-                    return factory.CreateLogger(Microsoft.Azure.WebJobs.Logging.LogCategories.CreateFunctionUserCategory(functionName));
-                })
-                .InstancePerLifetimeScope();
-        }
-    }
-
-``LoggerModule`` should be included in your project even if you don't use ``ILogger`` directly, since this interface is referenced by many of Microsoft's NuGet packages.
-
-Startup Class
-=============
-
-Finally, add a ``Startup`` class to tie everything together. This class is conceptually very similar to the ``Startup`` class in ASP.NET Core projects.
-
-The ``FunctionsStartup`` base class is provided by the ``Microsoft.Azure.Functions.Extensions`` NuGet package.
-
-.. sourcecode:: csharp
-
-    [assembly: FunctionsStartup(typeof(MyFunctionApp.Startup))]
-
-    namespace MyFunctionApp;
-
-    internal class Startup : FunctionsStartup
-    {
-        public override void Configure(IFunctionsHostBuilder builder)
-        {
-            // Use IServiceCollection.Add extension method to add features as needed, e.g.
-            builder.Services.AddDataProtection();
-
-            builder.Services.AddSingleton(GetContainer(builder.Services));
-
-            // Important: Use AddScoped so our Autofac lifetime scope gets disposed
-            // when the function finishes executing
-            builder.Services.AddScoped<LifetimeScopeWrapper>();
-
-            builder.Services.Replace(ServiceDescriptor.Singleton(typeof(IJobActivator), typeof(AutofacJobActivator)));
-            builder.Services.Replace(ServiceDescriptor.Singleton(typeof(IJobActivatorEx), typeof(AutofacJobActivator)));
-        }
-
-        private static IContainer GetContainer(IServiceCollection serviceCollection)
-        {
-            var containerBuilder = new ContainerBuilder();
-            containerBuilder.Populate(serviceCollection);
-            containerBuilder.RegisterModule<LoggerModule>();
-
-            // This is a convenient way to register all your function classes at once
-            containerBuilder.RegisterAssemblyTypes(typeof(Startup).Assembly)
-                .InNamespaceOf<Function1>();
-
-            // TODO: Register other dependencies with the ContainerBuilder like normal
-
-            return containerBuilder.Build();
-        }
-    }
-
-And that's it! Your function classes will now be resolved from Autofac.
-
-Example Function
-================
-
-Here's an example of an HTTP-triggered function that uses a service from dependency injection. Notice that the class and ``Run`` method are not static.
+Function classes are resolved from the container, so they take their dependencies through the constructor like anything else:
 
 .. sourcecode:: csharp
 
     public class Function1
     {
-        private readonly IRandomNumberService _randomNumberService;
+      private readonly IRandomNumberService _randomNumberService;
 
-        public Function1(IRandomNumberService randomNumberService)
-        {
-            _randomNumberService = randomNumberService;
-        }
+      public Function1(IRandomNumberService randomNumberService)
+      {
+        this._randomNumberService = randomNumberService;
+      }
 
-        // Call this by going to http://localhost:7071/api/Function1 in your web browser
-        [FunctionName("Function1")]
-        public IActionResult Run(
-            [HttpTrigger(AuthorizationLevel.Function, "get", Route = null)]
-            HttpRequest request
-        )
-        {
-            var number = _randomNumberService.GetDouble();
-
-            return new OkObjectResult($"Your random number is {number}.");
-        }
+      [Function(nameof(Function1))]
+      public IActionResult Run([HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequest request)
+      {
+        return new OkObjectResult($"Your random number is {this._randomNumberService.GetDouble()}.");
+      }
     }
 
+Logging needs nothing special. ``ILogger<T>`` is registered by the worker into the service collection and comes across into Autofac with everything else, so inject it where you need it.
 
-Acknowledgements
-================
+.. note::
 
-This guide was inspired by `Autofac.Extensions.DependencyInjection.AzureFunctions <https://github.com/junalmeida/autofac-azurefunctions>`_, a community NuGet package. Give ``Autofac.Extensions.DependencyInjection.AzureFunctions`` a try if you would prefer a NuGet package over the DIY approach presented here.
+   This page previously documented the **in-process** model, which required a custom ``IJobActivator``, a wrapper to dispose the lifetime scope, and a module to work around ``ILoggerFactory`` being registered after startup. That model has been retired by Microsoft, and none of that scaffolding is needed on the isolated worker. If you are still on it, `Microsoft's migration guidance <https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-to-isolated-model>`_ is the place to start.
+
+   The community `Autofac.Extensions.DependencyInjection.AzureFunctions <https://github.com/junalmeida/autofac-azurefunctions>`_ package targets the in-process model only, so it does not apply here.


### PR DESCRIPTION
Second half of the integration work. **184 lines → 48.**

## Why

The page documented the **in-process** model, which Microsoft has retired. Almost all of its length was scaffolding that model demanded and nothing else:

- a custom `AutofacJobActivator` implementing `IJobActivatorEx`
- a `LifetimeScopeWrapper` to get the request scope disposed
- a `LoggerModule` to work around `ILoggerFactory` being registered *after* `FunctionsStartup` ran

None of that applies on the isolated worker, which is an ordinary .NET generic host. Autofac attaches the same way it does everywhere else, so the page now mostly points at the pattern the other hosting pages already use. Logging in particular needs nothing at all — the worker registers `ILogger<T>` into the service collection and `Populate` carries it across, which is what removed the most awkward part of the old page.

## Evidence, not assumption

The package landscape confirms the split rather than me asserting it:

| Package | Latest | |
|---|---|---|
| `Microsoft.Azure.Functions.Extensions` | **1.1.0** | required by the old page; stalled |
| `Microsoft.Azure.Functions.Worker` | **2.52.0** | isolated worker; actively released |

And the community package the old page recommended as the easier alternative, `Autofac.Extensions.DependencyInjection.AzureFunctions`, describes itself as *"Autofac implementation of the dependency injection factory for **non isolated** Azure Functions"* — so it doesn't apply here at all. Worth stating explicitly, since the previous page steered readers toward it.

**The registration pattern was compiled and run before being written down**, against `Microsoft.Extensions.Hosting` 10.0.0 and `Autofac.Extensions.DependencyInjection` 11.0.2 — `UseServiceProviderFactory` plus `ConfigureContainer<ContainerBuilder>` on a `HostBuilder`, resolving a registered instance out of `host.Services`. That's a stronger check than reading signatures, and it's the part of the page a reader will copy.

## Not left as a dead end

A note records what the page used to cover and links Microsoft's migration guidance, so someone arriving from a search for `IJobActivator` or `FunctionsStartup` sees where it went rather than concluding the docs lost it.

## Verification limits, stated plainly

I can't reach Microsoft's docs from here, so two things are canonical-form rather than fetched: the migration-guidance URL, and `ConfigureFunctionsWorkerDefaults()` in the sample. The Autofac half of the sample is verified by execution. The newer `FunctionsApplication.CreateBuilder(args)` shape is deliberately **not** documented, because I couldn't verify how a service provider factory attaches to it and I'd rather show one pattern that works than two where one might not.

`sphinx -b html -W --keep-going`, `doc8`, `pre-commit` clean; nested-markup and bad-link scans clean; rendered HTML checked.
