### PR TITLE
Correct the release process and refresh the meta pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 User documentation is viewable at <https://docs.autofac.org> (a CNAME to <https://autofac.readthedocs.io>). It is stored in the `/docs` folder in this source repo.
 
-We also have API docs at <https://autofac.org/apidoc/>. This documentation is what gets put in the <https://github.com/autofac/autofac.github.com/tree/master/apidoc> folder.
+We also have API docs at <https://autofac.org/apidoc/>. This documentation is what gets put in the <https://github.com/autofac/autofac.github.com/tree/main/apidoc> folder.
 
 - [Checkout and Setup](#checkout-and-setup)
 - [Validating Changes](#validating-changes)
@@ -30,8 +30,8 @@ After cloning, set up the tools and dependencies.
 # Set up your Python virtual environment
 python3 -m venv .venv
 
-# Activate the virtual environment (cross-platform)
-.venv\Scripts\Activate.ps1
+# Activate the virtual environment
+.venv/bin/Activate.ps1   # .venv\Scripts\Activate.ps1 on Windows
 
 # Restore dependencies
 npm install
@@ -42,7 +42,7 @@ dotnet tool restore
 pre-commit install
 
 # At times you may need to FORCE PULL tags because the most recent doc version
-# tag follows the `master` branch.
+# tag follows the `main` branch.
 git pull --tags --force
 
 # When you're done, deactivate your virtual environment.
@@ -53,7 +53,6 @@ deactivate
 
 This repository uses `pre-commit` hooks to automatically validate code quality. These hooks run automatically when you commit, and include:
 
-- **eslint**: Lints JavaScript files
 - **markdownlint**: Checks Markdown formatting in `.md` files
 - **doc8**: Validates reStructuredText (`.rst`) files in the `docs/` folder for formatting and style issues
 - **General checks**: YAML/JSON validation, trailing whitespace, merge conflict markers, etc.
@@ -66,6 +65,10 @@ pre-commit run --all-files
 
 # Run the linting
 npm run lint
+
+# Build the docs the way CI does - warnings are errors, which is what
+# catches a broken :doc: reference that the linters cannot see
+python -m sphinx -b html -W --keep-going -d docs/_build/doctrees docs docs/_build/html
 ```
 
 ## VS Code Integration
@@ -78,9 +81,7 @@ The tasks all assume you're working with PowerShell since that's cross-platform.
 
 ## Updating User Docs
 
-To build the docs and see them locally, you need to follow the [Getting Started](https://docs.readthedocs.org/en/latest/getting_started.html) docs on Read The Docs so you get Python and Sphinx installed.
-
-The docs are written in [reStructuredText](http://sphinx-doc.org/rest.html), which is very similar to Markdown but not quite. References below.
+The docs are written in [reStructuredText](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html), which is similar to Markdown but not the same. References below.
 
 Updates to the documentation checked into the `/docs` folder will automatically propagate to Read The Docs. No build or separate push is required.
 
@@ -140,7 +141,7 @@ DocFX may generate warnings about missing XML documentation. These indicate meth
 
 ### Deploying API Documentation
 
-API documentation is automatically deployed to `autofac.github.com/apidoc/` when you push to the `master` branch (via the `.github/workflows/deploy-apidoc.yaml` workflow). The workflow:
+API documentation is automatically deployed to `autofac.github.com/apidoc/` when you push to the `main` branch (via the `.github/workflows/deploy-apidoc.yaml` workflow). The workflow:
 
 1. Builds the API documentation using DocFX
 2. Synchronizes the built docs to the `autofac/autofac.github.com` repository
@@ -167,20 +168,17 @@ To enable the automated deployment workflow, a repository admin must:
    - `APIDOCS_APP_ID`: The app ID from step 1
    - `APIDOCS_APP_PRIVATE_KEY`: The full contents of the `.pem` file from step 2 (including `-----BEGIN PRIVATE KEY-----` and `-----END PRIVATE KEY-----`)
 
-Once set up, pushing to `master` will automatically deploy updated API docs to `autofac.github.com/apidoc/`.
+Once set up, pushing to `main` will automatically deploy updated API docs to `autofac.github.com/apidoc/`.
 
 ## Updating the Primary Documentation Version
 
 When a new core Autofac version is released, we need to update the docs so that the "latest" is always tagged with the right Autofac version. This happens in a few places:
 
-1. In `./.github/workflows/update-version-tag.yaml` there is a tag setting that indicates which doc tag the `master` branch should follow. This keeps `latest` and that tag version in alignment.
+1. In `./.github/workflows/update-version-tag.yaml` there is a tag setting that indicates which doc tag the `main` branch should follow. This keeps `latest` and that tag version in alignment.
 2. In `./docs/conf.py` there are `version` and `release` values that indicate the version information that will be rendered into the pages.
 
 ## References
 
-- [ReStructured Text Quick Start](http://docutils.sourceforge.net/docs/user/rst/quickstart.html)
-- [ReStructured Text Quick Reference](http://docutils.sourceforge.net/docs/user/rst/quickref.html)
-- [ReStructured Text Cheat Sheet](http://docutils.sourceforge.net/docs/user/rst/cheatsheet.txt)
-- [ReStructured Text Primer](http://sphinx-doc.org/rest.html)
-- [Sphinx Markup Constructs](http://sphinx-doc.org/markup/index.html)
-- [ReadTheDocs Getting Started](https://docs.readthedocs.org/en/latest/getting_started.html)
+- [Sphinx reStructuredText documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html) - the primer, roles and directives
+- [docutils reStructuredText reference](https://docutils.sourceforge.io/rst.html) - the underlying specification
+- [Read the Docs documentation](https://docs.readthedocs.io/)

--- a/docs/best-practices/index.rst
+++ b/docs/best-practices/index.rst
@@ -2,7 +2,7 @@
 Best Practices and Recommendations
 ==================================
 
-You can always ask for Autofac usage guidance `on StackOverflow <https://stackoverflow.com/questions/tagged/autofac>`_ using the ``autofac`` tag or in `the discussion group <https://groups.google.com/forum/#forum/autofac>`_, but these quick tips can help get you going.
+You can always ask for Autofac usage guidance `on StackOverflow <https://stackoverflow.com/questions/tagged/autofac>`_ using the ``autofac`` tag or in `the discussion group <https://groups.google.com/g/autofac>`_, but these quick tips can help get you going.
 
 Always Resolve Dependencies from Nested Lifetimes
 =================================================
@@ -55,7 +55,7 @@ Autofac overrides component registrations by default. This means that an applica
 Use Profilers for Performance Checking
 ======================================
 
-Before doing any performance optimization or making assumptions about potential memory leaks, **always run a profiler** like `SlimTune <http://code.google.com/p/slimtune/>`_, `dotTrace <https://www.jetbrains.com/profiler/>`_, or `ANTS <https://www.red-gate.com/products/dotnet-development/ants-performance-profiler/>`_ to see where time is truly being spent. It might not be where you think.
+Before doing any performance optimization or making assumptions about potential memory leaks, **always run a profiler** - `dotTrace <https://www.jetbrains.com/profiler/>`_, `ANTS <https://www.red-gate.com/products/dotnet-development/ants-performance-profiler/>`_ and the `Visual Studio profiling tools <https://learn.microsoft.com/en-us/visualstudio/profiling/>`_ are all reasonable choices - to see where time is truly being spent. It might not be where you think.
 
 Register Once, Resolve Many
 ===========================
@@ -77,7 +77,7 @@ Becomes:
 
     builder.Register(c => new Component());
 
-This can yield an improvement of up to 10x faster ``Resolve()`` calls, but only makes sense for components that appear in many object graphs. See :doc:`the registration documentation <../register/index>` for more on lambda components.
+A lambda registration skips the reflection Autofac otherwise does to pick and invoke a constructor, so it resolves faster - but the size of the difference depends on the graph, and it only pays off for components that appear in a lot of them. Autofac has a `benchmark suite <https://github.com/autofac/Autofac/tree/develop/bench>`_ if you want to measure the effect on your own workload rather than take a number on faith. See :doc:`the registration documentation <../register/index>` for more on lambda components.
 
 Consider a Container as Immutable
 =================================

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -240,8 +240,7 @@ Need Help?
 ==========
 
 - You can `ask questions on StackOverflow <https://stackoverflow.com/questions/tagged/autofac>`_.
-- You can `participate in the Autofac Google Group <https://groups.google.com/forum/#forum/autofac>`_.
-- There's an introductory `Autofac tutorial <https://www.codeproject.com/KB/architecture/di-with-autofac.aspx>`_ on CodeProject.
+- You can `participate in the Autofac discussion group <https://groups.google.com/g/autofac>`_.
 - We have :doc:`advanced debugging tips <../troubleshooting/index>` if you want to dive deep.
 
 Building from Source

--- a/docs/owners.rst
+++ b/docs/owners.rst
@@ -65,7 +65,7 @@ Issue Review
 
 Issues come in for a lot of reasons - from questions to bug reports to enhancement requests.
 
-If the issue is a question, we generally try to get them to post to `StackOverflow <https://stackoverflow.com>`_ and tag the question ``autofac``. We do that because then the question can be searched by other people. People trying to figure out how something works largely won't come looking through the closed issues list in GitHub, so answering the question in GitHub only helps *that one person* while answering on StackOverflow can help many people. We also discourage folks from double-posting questions - if it's on StackOverflow *and* it's been filed on GitHub, put a link to the StackOverflow question in the issue and close the issue. (This information should also be in the issue template in every Autofac repo, so folks double-posting aren't actually reading the issue template.)
+If the issue is a question, we generally try to get them to post to `StackOverflow <https://stackoverflow.com/questions/tagged/autofac>`_ and tag the question ``autofac``. We do that because then the question can be searched by other people. People trying to figure out how something works largely won't come looking through the closed issues list in GitHub, so answering the question in GitHub only helps *that one person* while answering on StackOverflow can help many people. We also discourage folks from double-posting questions - if it's on StackOverflow *and* it's been filed on GitHub, put a link to the StackOverflow question in the issue and close the issue. (This information should also be in the issue template in every Autofac repo, so folks double-posting aren't actually reading the issue template.)
 
 If the issue is a bug report, we need some ability to reproduce the issue so we can verify it. Ideally this is in the form of a simple, self-contained failing unit test. If there is no reproduction, encourage the person to add one so you can more adequately help.
 
@@ -119,11 +119,9 @@ Support is one of those "hidden costs" of being an owner of an open source proje
 
 We accept support requests through a variety of channels.
 
-- `StackOverflow <https://stackoverflow.com>`_ with questions that are tagged ``autofac``.
-- `Google Groups <https://groups.google.com/forum/#!forum/autofac>`_
-- `Twitter <https://twitter.com/autofacioc>`_
-- `Gitter <https://gitter.im/autofac/Autofac>`_
-- GitHub issues (though, ideally, "How do I...?" sorts of questions go on StackOverflow)
+- `StackOverflow <https://stackoverflow.com/questions/tagged/autofac>`_ with questions tagged ``autofac``.
+- `The Autofac discussion group <https://groups.google.com/g/autofac>`_.
+- GitHub issues, though ideally "How do I...?" questions go to StackOverflow.
 
 At a minimum, as an owner you should subscribe to the ``autofac`` questions on SO and the Google Group.
 
@@ -174,17 +172,45 @@ From a general policy perspective, we should always be *compatible* with the lat
 Release Process
 ===============
 
-We follow the `Gitflow workflow process <https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow/>`_. Ongoing development should happen in the ``develop`` branch. Continuous integration builds get published to MyGet and can be consumed for testing purposes.
+We follow the `Gitflow workflow process <https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow/>`_. Ongoing development happens in the ``develop`` branch, and the release branch is ``main``.
 
-When it's time to cut a release, we'll:
+Pushes to ``develop`` publish packages to `GitHub Packages <https://github.com/orgs/autofac/packages>`_, which is where you get builds for testing before a release. Pushing a ``vX.Y.Z`` tag publishes to both GitHub Packages and NuGet - **the tag push is what releases to NuGet, not the push of** ``main``\ **.**
 
-- Ensure the semantic version is correct based on the changes since the last release. Update if needed, do a final CI build on the ``develop`` branch.
-- Merge ``develop`` into ``master`` and tag the repo with ``vX.Y.Z`` using the semantic version of the release.
-- After the CI build is complete and pushed to MyGet, push the package from MyGet to NuGet as the final release.
-- When NuGet has the new release, download the published package manually from NuGet.
-- Create a release page on the GitHub repository for the thing that just released. In that release page, add the release notes explaining the changes that have taken place. Upload the .nupkg you downloaded from NuGet so folks can get it if needed.
+**After a release,** ``develop`` **and** ``main`` **must point at the exact same commit hash.** Not equivalent content - the same hash. The release has to ship the commit that was actually built and validated on ``develop``.
 
-We maintain the manual .nupkg download because there are some areas around the world that may have NuGet blocked or strongly filtered. This allows those areas to manually get the library if they need it and host their own repository.
+To cut a release:
+
+#. Check the semantic version is right for the changes since the last release, update it in ``default.proj`` if needed, and let a final CI build run on ``develop``.
+#. Fast-forward ``main`` up to ``develop``:
+
+   .. sourcecode:: shell
+
+       git checkout main
+       git merge --ff-only develop
+
+   Always ``--ff-only``. If it refuses, ``main`` has commits ``develop`` doesn't - stop and reconcile. Do not fall back to a merge commit.
+#. Tag the release on ``main`` with ``git tag vX.Y.Z``, push ``main``, then push the tag.
+#. Switch back to ``develop`` locally, so nothing lands on ``main`` by accident.
+#. Confirm the two branches agree:
+
+   .. sourcecode:: shell
+
+       git rev-parse origin/develop origin/main
+
+   The two hashes must be identical.
+#. Write up the release on the GitHub releases page for the repository, explaining what changed. Packages come from the package sources; there is nothing to attach.
+
+**Never merge** ``develop`` **into** ``main``\ **, and never merge** ``main`` **back into** ``develop``\ **.** A ``--no-ff`` merge creates a commit that exists only on ``main`` - a commit that was never built on ``develop``, that changes the hash being released, and that leaves ``develop`` permanently one commit behind. That is exactly the drift the same-hash rule exists to prevent.
+
+If a release does end up with a merge commit on ``main``, fix it by fast-forwarding ``develop`` up to ``main`` instead:
+
+.. sourcecode:: shell
+
+    git checkout develop
+    git merge --ff-only origin/main
+    git push origin develop
+
+That moves the ``develop`` pointer without creating a commit, leaving both tips on the same hash.
 
 You Are Not Alone
 =================

--- a/docs/owners.rst
+++ b/docs/owners.rst
@@ -200,7 +200,9 @@ To cut a release:
    The two hashes must be identical.
 #. Write up the release on the GitHub releases page for the repository, explaining what changed. Packages come from the package sources; there is nothing to attach.
 
-**Never merge** ``develop`` **into** ``main``\ **, and never merge** ``main`` **back into** ``develop``\ **.** A ``--no-ff`` merge creates a commit that exists only on ``main`` - a commit that was never built on ``develop``, that changes the hash being released, and that leaves ``develop`` permanently one commit behind. That is exactly the drift the same-hash rule exists to prevent.
+**Never create a merge commit between the two branches, in either direction.** ``--ff-only`` is the only merge that should ever run against them; if it refuses, stop and reconcile rather than dropping the flag. A ``--no-ff`` merge produces a commit that exists only on ``main`` - one that was never built on ``develop``, that changes the hash being released, and that leaves ``develop`` permanently one commit behind. That is exactly the drift the same-hash rule exists to prevent.
+
+Standard Gitflow would also have you merge the release branch back into ``develop`` when you're done. Don't. The fast-forward already left both branches on the same commit, so there is nothing to merge back.
 
 If a release does end up with a merge commit on ``main``, fix it by fast-forwarding ``develop`` up to ``main`` instead:
 

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -8,20 +8,7 @@ Community Support
 Autofac has a large community that can help you out if you have questions. If you can't find your answer in the documentation, you can...
 
 - `Ask your question on StackOverflow <https://stackoverflow.com/questions/tagged/autofac>`_. Be sure to use the ``autofac`` tag in your question.
-- `Start a discussion on the forum <https://groups.google.com/forum/#forum/autofac>`_. This is a good idea if you have multiple questions or a question that might have a more subjective answer (e.g., "recommendations" sorts of things).
-
-Commercial Support
-==================
-
-Several companies offer commercial support for Autofac questions/design issues:
-
-- `Readify <http://readify.net>`_ - training and consulting services
-- `CICLO <http://ciclo.pt/>`_ - commercial support and training
-- `Continuous IT <http://continuousit.com>`_ - training, troubleshooting and implementation help
-
-Note: while the above listed companies offer help, they are not officially affiliated with the Autofac project.
-
-*If you would like your company listed here, please send an email to the discussion group.*
+- `Start a discussion in the Autofac group <https://groups.google.com/g/autofac>`_. This is a good idea if you have multiple questions or a question that might have a more subjective answer (e.g., "recommendations" sorts of things). It is quieter than StackOverflow, but it is read.
 
 Filing an Issue
 ===============


### PR DESCRIPTION
Phase 3g. The sharpest defect left in the docs, plus the meta-page cleanup.

## The release process was documented backwards

`owners.rst` told a new owner to:

> Merge `develop` into `master` and tag the repo with `vX.Y.Z` […] After the CI build is complete and pushed to MyGet, push the package from MyGet to NuGet as the final release. […] download the published package manually from NuGet […] Upload the .nupkg

**A merge is the one operation that must not happen.** `develop` and `main` have to end up on the *exact same commit hash*, because the release ships the commit that was built and validated on `develop`. A `--no-ff` merge creates a commit that exists only on `main` — never built on `develop`, changing the released hash, and leaving `develop` permanently one behind. The guide was instructing owners to cause precisely the drift the real procedure exists to prevent.

The section now documents the fast-forward-only procedure, states which operations are forbidden and why, and includes the recovery if a merge commit does land (fast-forward `develop` up to `main`, which moves a pointer rather than creating a commit).

## Publishing, checked against the CI rather than rewritten from memory

From the shared `ci.yml`, the `publish` job runs on `develop` pushes and on `v*` tags:

| Trigger | GitHub Packages | NuGet.org |
|---|---|---|
| push to `develop` | yes | no |
| `vX.Y.Z` tag | yes | **yes** |

So **the tag push is what releases** — not the push of `main`. MyGet is gone, and there's no manual download-and-upload step: core Autofac stopped attaching packages to releases in 8.3.0, which also retires the old rationale about NuGet being filtered in some regions.

## Support channels now agree with each other

Four pages disagreed. `owners.rst`, `support.rst`, `best-practices` and `getting-started` now all say StackOverflow, the Autofac group, and GitHub issues. Gitter and Twitter dropped, commercial support section removed, and the four Google Group links — which were in **three different URL formats** — are all `groups.google.com/g/autofac`.

**With these gone, the docs contain no dead hosts anywhere.** That closes out the link work started in #198.

## Two stale recommendations

- **SlimTune** was hosted on Google Code, shut down in 2016. The profiler list is now three live options.
- **"up to 10x faster"** for lambda registration is a precise number nobody can substantiate against a current release, and it predates both the 6.x pipeline rework and the 9.1 performance pass. Replaced with what is actually true — reflection is skipped, the gain depends on the graph — plus a pointer to Autofac's benchmark suite for anyone who wants to measure their own workload. I considered running the `LambdaResolveBenchmark` to produce a current figure, but a laptop BenchmarkDotNet run isn't a number worth publishing.
- The CodeProject tutorial link is dropped: it predates Autofac 3 and shows APIs that no longer exist.

## CONTRIBUTING.md

Five references to a `master` branch that doesn't exist; **eslint listed as a pre-commit hook** when the hooks are `check-json`, `check-yaml`, `check-merge-conflict`, `end-of-file-fixer`, `trailing-whitespace`, `markdownlint`, `doc8`, `json-sort` (eslint runs via `npm run lint`); and a Windows-only `.venv\Scripts\Activate.ps1` under a comment claiming it was cross-platform. It now also shows the docs build CI runs, since that's the check which catches a broken cross-reference the linters can't see.

The rotting deep-link list in References collapsed to three durable targets, and `docs.readthedocs.org` / `docutils.sourceforge.net` moved to their current `.io` domains.

## Verification

The release procedure is transcribed from the project's own documented process; publishing behavior from `autofac/.github`'s `ci.yml`; the hook list from `.pre-commit-config.yaml`.

`sphinx -W`, `doc8`, `pre-commit`, `npm run lint` all clean. Both custom scans clean.

Two things the tooling caught on me during this, worth noting since they're the reason those checks exist: I wrote **nested inline markup** in three places in the new release section (literals inside bold), caught by the scan; and unifying a StackOverflow URL created a **duplicate explicit target name**, caught by `doc8`.
