### PR TITLE
Refresh the release notes list and add the 7-to-8 and 8-to-9 upgrade pages

### DIFF
--- a/docs/whats-new/index.rst
+++ b/docs/whats-new/index.rst
@@ -5,6 +5,7 @@ What's New
 .. toctree::
 
     releasenotes.rst
+    upgradingfrom7to8.rst
     upgradingfrom6to7.rst
     upgradingfrom5to6.rst
     upgradingfrom3to4.rst

--- a/docs/whats-new/index.rst
+++ b/docs/whats-new/index.rst
@@ -5,6 +5,7 @@ What's New
 .. toctree::
 
     releasenotes.rst
+    upgradingfrom8to9.rst
     upgradingfrom7to8.rst
     upgradingfrom6to7.rst
     upgradingfrom5to6.rst

--- a/docs/whats-new/releasenotes.rst
+++ b/docs/whats-new/releasenotes.rst
@@ -31,7 +31,6 @@ Release notes for Autofac and integration packages are all stored in the GitHub 
  - `Common Service Locator <https://github.com/autofac/Autofac.Extras.CommonServiceLocator/releases>`_
  - `Moq <https://github.com/autofac/Autofac.Extras.Moq/releases>`_
  - `FakeItEasy <https://github.com/autofac/Autofac.Extras.FakeItEasy/releases>`_
- - `MvvmCross <https://github.com/autofac/Autofac.Extras.MvvmCross/releases>`_
 
 * Multitenancy
 
@@ -44,3 +43,4 @@ Release notes for Autofac and integration packages are all stored in the GitHub 
  - `Aggregate Services <https://github.com/autofac/Autofac.Extras.AggregateService/releases>`_
  - `Attribute Metadata <https://github.com/autofac/Autofac.Extras.AttributeMetadata/releases>`_
  - `Dynamic Proxy / Interception <https://github.com/autofac/Autofac.Extras.DynamicProxy/releases>`_
+ - `Pooled Instances <https://github.com/autofac/Autofac.Pooling/releases>`_

--- a/docs/whats-new/upgradingfrom7to8.rst
+++ b/docs/whats-new/upgradingfrom7to8.rst
@@ -1,0 +1,11 @@
+=================================
+Upgrading from Autofac 7.x to 8.x
+=================================
+
+Very little changed for most people in the 8.x line. Beyond the target framework updates, there are two breaking changes, both narrow enough that you will probably only meet them if you write code against Autofac's internals.
+
+- ``ResolveRequest`` became a ``readonly struct``, where it had been a class. Code that treats it as a reference type no longer compiles - comparing one to ``null`` is the usual way this shows up. It is also copied by value now, so a method taking one cannot mutate the caller's copy. This only affects code that handles ``ResolveRequest`` directly, which in practice means custom :doc:`resolve middleware <../advanced/pipelines>` or a custom ``IInstanceActivator``.
+
+- The shim ``RequiresUnreferencedCodeAttribute`` that Autofac declares for older target frameworks changed from ``public`` to ``internal`` in 8.4.0. If you were applying that attribute in your own code and picking up Autofac's declaration of it, declare your own or reference the framework one instead.
+
+There is no separate page for 8.x to 9.x. That release only changed target frameworks - dropping ``net6.0`` and ``net7.0``, adding ``net10.0`` - so the compiler tells you everything you need to know.

--- a/docs/whats-new/upgradingfrom7to8.rst
+++ b/docs/whats-new/upgradingfrom7to8.rst
@@ -7,5 +7,3 @@ Very little changed for most people in the 8.x line. Beyond the target framework
 - ``ResolveRequest`` became a ``readonly struct``, where it had been a class. Code that treats it as a reference type no longer compiles - comparing one to ``null`` is the usual way this shows up. It is also copied by value now, so a method taking one cannot mutate the caller's copy. This only affects code that handles ``ResolveRequest`` directly, which in practice means custom :doc:`resolve middleware <../advanced/pipelines>` or a custom ``IInstanceActivator``.
 
 - The shim ``RequiresUnreferencedCodeAttribute`` that Autofac declares for older target frameworks changed from ``public`` to ``internal`` in 8.4.0. If you were applying that attribute in your own code and picking up Autofac's declaration of it, declare your own or reference the framework one instead.
-
-There is no separate page for 8.x to 9.x. That release only changed target frameworks - dropping ``net6.0`` and ``net7.0``, adding ``net10.0`` - so the compiler tells you everything you need to know.

--- a/docs/whats-new/upgradingfrom8to9.rst
+++ b/docs/whats-new/upgradingfrom8to9.rst
@@ -1,0 +1,31 @@
+=================================
+Upgrading from Autofac 8.x to 9.x
+=================================
+
+There are no public API changes in this one. Everything that compiled against 8.x still compiles against 9.x - the changes are in which frameworks Autofac targets and which versions of two dependencies come with it.
+
+Target Frameworks
+=================
+
+``net6.0`` and ``net7.0`` were dropped, and ``net10.0`` added. The target set went from ``net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0`` to ``net10.0;net8.0;netstandard2.1;netstandard2.0``.
+
+If your application still targets ``net6.0`` or ``net7.0`` you can keep using this release, because both of those implement ``netstandard2.1`` and will resolve that asset instead. You lose nothing functionally; you are simply no longer running against a framework-specific build.
+
+Dependencies
+============
+
+Two package references moved to their 10.x versions, and because they flow to you transitively they raise the floor for your application too:
+
+- ``System.Diagnostics.DiagnosticSource`` from 8.0.1 to 10.0.0, on every target framework.
+- ``Microsoft.Bcl.AsyncInterfaces`` from 8.0.0 to 10.0.0, on the ``netstandard2.0`` target only.
+
+If something else in your dependency graph pins either of those to an 8.x version, that is the conflict to expect.
+
+What You Gain
+=============
+
+The 9.x line added a fair amount that is worth knowing about once you have upgraded:
+
+- :doc:`Native support for AnyKey and the ServiceKey attribute <../advanced/keyed-services>`, so a single registration can answer any key and a component can be told which key it was resolved under.
+- :doc:`Opt-in metrics <../troubleshooting/metrics>` for resolve timing and lock contention.
+- :doc:`Trimming and Native AOT annotations <../advanced/native-aot-trimming>`, which let the compiler tell you which Autofac features are safe to trim.


### PR DESCRIPTION
Phase 3h. Small, but it revises one decision from the plan.

## Release notes list

Rather than reading down the list, I checked **every** repository it links against the GitHub API:

- **`Autofac.Extras.MvvmCross` is archived** — entry removed. The other 23 are active.
- Comparing the list against the set of shipping packages turned up exactly one omission: **`Autofac.Pooling`**, now listed under extended features.

## A plan revision: 8.x does need an upgrade page

The approved plan said to add "a short note that 8.0 and 9.0 were TFM-only rather than new upgrade-guide pages." That was right about 9.0 and **wrong about 8.0**.

`ResolveRequest` went from a class to a `readonly struct`:

```csharp
public readonly struct ResolveRequest : IEquatable<ResolveRequest>
```

That's a compile break, not a target-framework change. Comparing one to `null` stops working, and it's copied by value now, so a method taking one can't mutate the caller's copy. The affected audience — custom resolve middleware and custom `IInstanceActivator` implementations — is exactly who the 5-to-6 page was written for, which is what convinced me it deserves the same treatment.

The page also records the 8.4.0 change making the shim `RequiresUnreferencedCodeAttribute` `internal` (verified: it's `internal sealed class` in `LinkerAttributes.cs`, and the commit making it so is in history).

## 8.x to 9.x now has a page too

Added on review feedback, and the reasoning is better than mine was: leaving it out puts a hole in the series, which reads as an oversight rather than as "nothing happened" — and it would look stranger still once a 9-to-10 page sits next to a missing 8-to-9. The sentence in the 7-to-8 page explaining why there was no 8-to-9 page is removed accordingly.

Upgrade pages are the one place target-framework changes belong — it's what the 6-to-7 page does for `net5.0` — so this one leads with them. Checked against the project files rather than the release notes:

| | Target frameworks |
|---|---|
| 8.4.0 | `net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0` |
| 9.x | `net10.0;net8.0;netstandard2.1;netstandard2.0` |

So `net6.0` and `net7.0` dropped, `net10.0` added. Applications still on `net6.0`/`net7.0` can consume the release through `netstandard2.1` — the same framing the 6-to-7 page used for `net5.0`.

The **dependency bumps are the part with real consequences**, since they flow transitively and raise the floor for consuming applications. I read the conditions off the csproj so the page says which targets each affects rather than implying both apply everywhere:

- `System.Diagnostics.DiagnosticSource` 8.0.1 → 10.0.0, on **every** target
- `Microsoft.Bcl.AsyncInterfaces` 8.0.0 → 10.0.0, on **`netstandard2.0` only**

A closing section points at what 9.x added — `AnyKey` and `[ServiceKey]`, opt-in metrics, trimming and AOT annotations — so the page is worth opening even though the upgrade itself asks nothing of you.

## Verification

`sphinx -W`, `doc8`, `pre-commit`, `npm run lint` clean. Nested-markup and bad-link scans clean. Confirmed the new page uses the overline-plus-underline title convention established in #197, and that the `whats-new` toctree renders in the right order with the new page ahead of 6-to-7.

## Note on sequencing

This is independent of the outstanding stub work. `owners.rst` and `support.rst` still need reducing to stubs, but that has to wait for autofac/.github#2 to merge — the stubs link to `MAINTAINERS.md`, which doesn't exist on `main` yet, and I'd rather not ship a PR that knowingly introduces a 404.

