### PR TITLE
Add FAQ pages for container immutability and plugin assemblies

### DIFF
--- a/docs/faq/conditional-registration.rst
+++ b/docs/faq/conditional-registration.rst
@@ -21,6 +21,11 @@ Use Modules
 
 There is an example of this :doc:`in the documentation for Autofac modules <../configuration/modules>`.
 
+Conditional Registration
+========================
+
+If the condition is "only register this when something else hasn't already," Autofac has that built in. ``OnlyIf()`` takes a predicate over the registrations made so far, and ``IfNotRegistered()`` is the shorthand for standing down when a service already has a provider. :ref:`Both are covered in the registration documentation <register-conditional-registration>`.
+
 Lambda Registrations
 ====================
 

--- a/docs/faq/index.rst
+++ b/docs/faq/index.rst
@@ -9,6 +9,8 @@ Frequently Asked Questions
     instance-per-session.rst
     iis-restart.rst
     conditional-registration.rst
+    update-container.rst
+    plugin-assemblies.rst
     share-across-app-types.rst
     isolate-autofac.rst
     binding-redirect.rst

--- a/docs/faq/plugin-assemblies.rst
+++ b/docs/faq/plugin-assemblies.rst
@@ -1,0 +1,50 @@
+=============================================
+Why isn't my plugin assembly getting loaded?
+=============================================
+
+Because Autofac isn't the thing that loads it. **Autofac scans assemblies you hand it; it never finds or loads assemblies on your behalf.** ``RegisterAssemblyTypes(someAssembly)`` needs an ``Assembly`` object, and getting one is the runtime's job, not the container's.
+
+This trips people up because plugins usually get wired up through the container, so a plugin that fails to show up looks like a registration problem. If the type isn't in the container, the question to ask first is whether the assembly was ever loaded - not whether the scan matched.
+
+.. contents::
+  :local:
+
+Confirming Where the Problem Is
+===============================
+
+Check whether the assembly is loaded before looking at registrations at all:
+
+.. sourcecode:: csharp
+
+    // If your plugin assembly isn't in here, no amount of registration
+    // configuration will help.
+    foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+    {
+      Console.WriteLine(assembly.FullName);
+    }
+
+If it is loaded and the types still aren't resolving, then it is a registration question, and :doc:`the assembly scanning documentation <../register/scanning>` is the place to go - particularly the filtering rules, since ``AsImplementedInterfaces`` and ``Where`` clauses quietly exclude more than people expect.
+
+How Assemblies Get Found Differs by Application
+===============================================
+
+There is no single answer, which is much of why this is hard:
+
+- **Modern .NET** loads on demand and does not sweep the output folder. Unreferenced assemblies need locating and loading explicitly, usually through an ``AssemblyLoadContext``. :doc:`Autofac supports scoping registrations to a load context <../advanced/scopes-loadcontexts>` so plugin types can be unloaded again.
+- **ASP.NET classic** has its own rules. Assemblies for a web application are managed by ``BuildManager``, and a plugin assembly that isn't referenced has to be registered with it - :doc:`the MVC integration page covers doing that <../integration/mvc>`. Scanning ``AppDomain.CurrentDomain.GetAssemblies()`` in a web app is also unreliable, :doc:`for reasons the IIS restart FAQ explains <iis-restart>`.
+- **Console and desktop applications** on .NET Framework behave differently again, resolving from the application base and probing paths.
+
+`The configuration example <https://github.com/autofac/Examples/tree/main/src/ConfigurationExample>`_ shows one way to handle this on modern .NET, hooking ``AssemblyLoadContext.Default.Resolving`` to load a plugin assembly from the output folder. Treat it as an illustration of the shape of the problem, not as a recommendation - it is deliberately the simplest thing that works for an example.
+
+Things Autofac Does Not Decide For You
+======================================
+
+If you are building a plugin system rather than loading one assembly, the design questions below are yours. None of them have Autofac answers, and picking differently changes what your loading code has to do:
+
+- **Where plugins live.** A known folder, configuration, a package feed, somewhere else.
+- **How plugin dependencies resolve.** Two plugins wanting different versions of the same library is the case that hurts, and isolating them means separate load contexts.
+- **Whether plugins can be unloaded.** Unloading requires a collectible load context and that nothing outside it holds a reference, which is difficult to guarantee.
+- **Trust.** Loading an assembly runs its code. If plugins are not fully trusted, inspecting before loading is a decision to make deliberately.
+- **What counts as a plugin.** An interface, an attribute, a naming convention - this one is the only piece Autofac participates in, through the scanning filters.
+
+Getting those right is what makes plugins work. Registration is the last and smallest step.

--- a/docs/faq/update-container.rst
+++ b/docs/faq/update-container.rst
@@ -1,0 +1,51 @@
+===================================================================
+How do I change registrations after the container is built?
+===================================================================
+
+You don't. A container is immutable once ``Build()`` returns - ``ContainerBuilder.Update`` was obsoleted in Autofac 4.x and removed in 5.0. :doc:`The reasoning is in the best practices <../best-practices/index>`: components already resolved, singletons already cached, and auto-start components already run would all be inconsistent with the new contents.
+
+What you almost always want instead is one of two things: decide the registration up front, or scope the difference to a child lifetime scope.
+
+.. contents::
+  :local:
+
+Decide at Registration Time
+===========================
+
+If what varies is known when the application starts - an environment, a configuration value, a feature flag - register the variation rather than patching it in later. :doc:`The conditional registration FAQ covers the options <conditional-registration>`: configuration files, parameterized modules, and lambda registrations that make the choice as they run.
+
+:ref:`Conditional registration <register-conditional-registration>` is worth knowing about here too. ``OnlyIf()`` and ``IfNotRegistered()`` let a registration stand down when something else has already claimed the service, which covers the "register a default unless the host supplied one" case without any need to modify the container afterward.
+
+Register in a Child Lifetime Scope
+==================================
+
+If the difference belongs to one unit of work, one request, or one tenant, add it to a :doc:`child lifetime scope <../lifetime/working-with-scopes>` instead of the container. ``BeginLifetimeScope`` takes a configuration action, and registrations made there are visible inside that scope and nowhere else:
+
+.. sourcecode:: csharp
+
+    using (var scope = container.BeginLifetimeScope(builder =>
+      {
+        builder.RegisterInstance(currentUser).As<IUser>();
+      }))
+    {
+      // Anything resolved here sees the extra registration.
+      var service = scope.Resolve<IService>();
+    }
+
+Nothing says a scope has to be short-lived. You can create one at startup, keep it for the life of the application, and treat it as a smaller container with a specific purpose - which is precisely how :doc:`multitenant support <../advanced/multitenant>` works, with a cached scope per tenant.
+
+Be aware that scope-level registrations do not reach back up. A ``SingleInstance`` component owned by the root container gets its dependencies from the root, so overriding one of those dependencies in a child scope will not change what the singleton already holds. :doc:`The lifetime scope documentation explains why <../lifetime/index>`.
+
+Pass the Builder, Not the Container
+===================================
+
+If the reason you wanted to update the container is that registrations are contributed from several places during startup, pass the ``ContainerBuilder`` around instead of the built container and let each part register into it before anything calls ``Build()``. ``ContainerBuilder.Properties`` is available for carrying context between those parts, so decisions that depend on earlier registrations can still be made.
+
+This is what the :doc:`ASP.NET Core integration <../integration/aspnetcore>` does. ``ConfigureContainer`` hands you the builder rather than the container, so the framework's registrations and yours are combined before the container exists.
+
+If You Truly Cannot Know Up Front
+=================================
+
+Register a factory or an indirection instead of the component. A lambda registration is evaluated at resolve time, so a component that reads from mutable state you control - a settings object, a registry you own - can change behavior without the container changing. The container stays fixed while the value it produces does not.
+
+That indirection is the supported way to get late-bound behavior, and it keeps the thing Autofac guarantees intact: what is registered when the container is built is what is registered for its lifetime.

--- a/docs/register/registration.rst
+++ b/docs/register/registration.rst
@@ -427,6 +427,8 @@ To override this behavior, use the ``PreserveExistingDefaults()`` modifier:
 
 In this scenario, ``ConsoleLogger`` will be the default for ``ILogger`` because the later registration for ``FileLogger`` used ``PreserveExistingDefaults()``.
 
+.. _register-conditional-registration:
+
 Conditional Registration
 ========================
 


### PR DESCRIPTION
Fixes #97. Fixes #101. The last two open issues.

Both were filed as FAQ requests, and both are questions people reach from a **wrong premise** — so each page leads by correcting it rather than answering the question as asked.

## #97 — "How do I change registrations after the container is built?"

The premise is that you can. You can't, and the useful content is what to do instead. The alternatives come from autofac/Autofac#811, the discussion the issue points at: decide at registration time, scope the difference to a child lifetime scope, or pass the builder rather than the container.

**The page cross-references rather than restates.** The *reasoning* for immutability is already in best practices, and configuration, modules and lambdas are already in the conditional-registration FAQ — so this page links both instead of growing a fourth copy.

One addition worth calling out: it warns that **scope-level registrations don't reach back up into a root-owned singleton.** That's what people try next when a child-scope override appears not to work, and it's the point at which the immutability question usually gets re-asked.

The issue also asked to check for remaining `ContainerBuilder.Update` references in the docs. **There are none.**

### A gap this turned up

Writing that page meant linking the conditional-registration FAQ, and the page titled *"How do I conditionally register components?"* never mentioned `OnlyIf` or `IfNotRegistered` — the feature literally named conditional registration. It covered configuration, modules and lambdas and stopped.

It does now, pointing at the full treatment in the registration docs, which gained a `:ref:` label so it can be linked directly.

## #101 — "Why isn't my plugin assembly getting loaded?"

The premise is that a plugin failing to appear is a registration problem. **Autofac scans assemblies it is handed; it never locates or loads one.** So the page opens with how to tell the two apart — enumerate the loaded assemblies before touching any registration config — because that one check decides which half of the problem you have.

Then why the answer differs by application type: modern .NET loading on demand via `AssemblyLoadContext`, ASP.NET classic going through `BuildManager`, desktop probing paths. Each links existing material — the load-context page, the MVC plugin-assembly section, the IIS restart FAQ — rather than duplicating it.

The design considerations from the issue are framed as **decisions Autofac does not make**: where plugins live, how their dependencies resolve, whether they can be unloaded, trust, and what marks a type as a plugin. Only the last involves Autofac at all.

The configuration example is linked as the issue asked, explicitly as an illustration and not a recommendation — matching the issue's own framing. I read it first to confirm it still demonstrates what's claimed: it hooks `AssemblyLoadContext.Default.Resolving` to load a plugin from the output folder.

## Verification

`sphinx -W`, `doc8`, `pre-commit`, `npm run lint` clean. Nested-markup and bad-link scans clean. FAQ titles are sentence case per the documented exception; both new pages appear in the toctree in sensible positions.

Worth noting `-W` earned its place again: I initially wrote a `:ref:` to a label that didn't exist. The build would have failed on it, which is why the label got added properly instead.
