### PR TITLE
Switch the docs theme to Furo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,12 +98,18 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'furo'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# The source_* keys render the "Edit this page" link. Read the Docs injects an
+# equivalent of its own, but Furo doesn't read that context.
+html_theme_options = {
+    'source_repository': 'https://github.com/autofac/Documentation/',
+    'source_branch': 'main',
+    'source_directory': 'docs/',
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sphinx>=9.1.0
 sphinx-autobuild>=2025.8.25
-sphinx_rtd_theme>=3.1.0
+furo>=2025.12.19
 doc8>=2.0.0
 pre-commit>=4.6.2


### PR DESCRIPTION
Replaces `sphinx_rtd_theme` with [Furo](https://github.com/pradyunsg/furo). Modern look, dark mode, actively developed, and no structural cost to this site.

## Why Furo and not something else

I built the whole site against Furo and [Shibuya](https://shibuya.lepture.com/) and compared both to the current output. Every construct the docs actually depend on renders correctly in all three, and all three build with zero warnings:

| | rtd | furo | shibuya |
| --- | --- | --- | --- |
| `.. contents:: :local:` | ok | ok | ok |
| Grid tables (pipeline phases) | ok | ok | ok |
| Simple tables (glossary) | ok | ok | ok |
| Code highlighting | ok | ok | ok |
| Admonitions | ok | ok | ok |
| Images | ok | ok | ok |
| Search index | ok | ok | ok |

Shibuya lost on one concrete point: it collapses the landing page's table of contents. `index.rst` uses `:maxdepth: 3` and *is* the site map, so that depth matters.

```text
index.html, main content area:
  rtd       l1=17  l2=85  l3=190
  furo      l1=17  l2=85  l3=190
  shibuya   l1=17  l2=68  l3=5
```

Adopting Shibuya would have meant rewriting `index.rst` into a hand-written landing page. Furo is a drop-in, and its sidebar is richer on deep pages (`l2=71` against rtd's `11`).

## The one thing that isn't just a theme name

Read the Docs injects the "Edit on GitHub" link into `sphinx_rtd_theme` through its own template context, which Furo doesn't read. `html_theme_options.source_repository` is Furo's native equivalent, so the link survives the switch:

```html
href="https://github.com/autofac/Documentation/edit/main/docs/integration/aspnetcore.rst"
```

`extensions` is empty and `html_static_path` is `[]`, so nothing else was coupled to the old theme. The `epub` and `pdf` formats in `.readthedocs.yaml` use their own builders and ignore `html_theme`.

## Verification

- `sphinx -b html -W --keep-going` — succeeds, 95 pages, zero warnings (matches Read the Docs' `fail_on_warning`)
- `doc8` — 187 files, 0 errors
- `pre-commit run --all-files` — all hooks pass
- `npm run lint` — clean
