### PR TITLE
Add a copy button to code samples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ import os
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ['sphinx_copybutton']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 sphinx>=9.1.0
 sphinx-autobuild>=2025.8.25
+sphinx-copybutton>=0.5.2
 furo>=2025.12.19
 doc8>=2.0.0
 pre-commit>=4.6.2


### PR DESCRIPTION
Adds [sphinx-copybutton](https://sphinx-copybutton.readthedocs.io/), which puts a copy button in the corner of every code sample. The docs carry 478 C# samples and copying one meant selecting it by hand.

## Why there's no configuration

Copybutton's common gotchas both turned out not to apply here, so the defaults are correct as-is:

- **Shell prompts.** If samples began with `$` or `PS>`, the prompt would get copied along with the command and `copybutton_prompt_text` would be needed. Nothing in `docs/` uses a prompt — the two `shell` blocks are bare commands.
- **Line numbers.** No block uses `:linenos:`, so there are no line numbers to strip.

That keeps this to one extension name and one requirement.

## Verification

The button is injected client-side, so I checked the parts that can be verified in the build output rather than assuming it works:

- Assets emitted: `copybutton.js`, `copybutton.css`, `copybutton_funcs.js`, `clipboard.min.js`
- Actually referenced from page `<head>`, not just copied into `_static`
- Its target selector is `div.highlight pre`, and `register/registration.html` alone has 64 matching blocks

Plus the usual suite:

- `sphinx -b html -W --keep-going` — succeeds, 95 pages, zero warnings
- `doc8` — 187 files, 0 errors
- `pre-commit run --all-files` — all hooks pass
- `npm run lint` — clean
