### PR TITLE
Add a themed 404 page and a page-level sitemap

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ import os
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx_copybutton']
+extensions = ['sphinx_copybutton', 'notfound.extension', 'sphinx_sitemap']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -110,6 +110,19 @@ html_theme_options = {
     'source_branch': 'main',
     'source_directory': 'docs/',
 }
+
+# Where Read the Docs serves the default version. Sphinx emits this as
+# <link rel="canonical">, and sphinx-sitemap builds every URL from it.
+html_baseurl = 'https://docs.autofac.org/en/latest/'
+
+# html_baseurl already carries the language and version, so the sitemap only
+# needs the page link appended. The default scheme would repeat both, and would
+# use the version above ('9.0') rather than the 'latest' the site is served at.
+sitemap_url_scheme = '{link}'
+
+# Generated pages with nothing to index; the 404 in particular should never be
+# advertised to a crawler.
+sitemap_excludes = ['404.html', 'search.html', 'genindex.html']
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 sphinx>=9.1.0
 sphinx-autobuild>=2025.8.25
 sphinx-copybutton>=0.5.2
+sphinx-notfound-page>=1.1.0
+sphinx-sitemap>=2.9.0
 furo>=2025.12.19
 doc8>=2.0.0
 pre-commit>=4.6.2


### PR DESCRIPTION
Adds [sphinx-notfound-page](https://sphinx-notfound-page.readthedocs.io/) and [sphinx-sitemap](https://sphinx-sitemap.readthedocs.io/).

## Why each one

**404 page.** On a custom domain, Read the Docs serves a generic 404 that has none of our theme or navigation. `sphinx-notfound-page` generates a `404.html` that Read the Docs serves instead. The subtlety is that a 404 is served from *any* URL depth, so relative asset links would break — the extension rewrites them absolute:

```html
href="/en/latest/_static/styles/furo.css?v=7bdb33bb"
```

Verified: 28 KB, Furo-themed (`sidebar-drawer` markup present), and **zero** remaining `../` links.

**Sitemap.** Read the Docs generates a `sitemap.xml` listing *version roots*, not individual pages. `sphinx-sitemap` complements it with a page-level sitemap — 93 URLs.

## The two settings that aren't obvious

`html_baseurl` was not previously set. It does double duty: Sphinx emits it as `<link rel="canonical">`, and sphinx-sitemap builds every URL from it.

```html
<link rel="canonical" href="https://docs.autofac.org/en/latest/register/registration.html">
```

`sitemap_url_scheme = '{link}'` is required *because* of that value. `html_baseurl` already carries the language and version, and the default scheme (`{lang}{version}{link}`) would repeat both — and would use `version` from `conf.py` (`9.0`) rather than the `latest` the site is actually served at, producing URLs that 404.

`sitemap_excludes` drops `404.html`, `search.html` and `genindex.html`. The 404 in particular should never be advertised to a crawler; it was in the first build I ran. `glossary.html` is real content and stays.

## Verification

- `sphinx -b html -W --keep-going` — succeeds, zero warnings
- Sitemap 96 → 93 URLs after exclusions, exactly the three dropped, no doubled `en/latest` prefix
- `doc8`, `pre-commit run --all-files`, `npm run lint` — all clean
